### PR TITLE
[WIP]インポート周りの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,8 @@ gem 'erb2haml'
 
 gem 'font-awesome-rails'
 
+gem 'select2-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    select2-rails (4.0.3)
+      thor (~> 0.14)
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -268,6 +270,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
+  select2-rails
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,4 +17,4 @@
 //= require_tree .
 //= require bootstrap
 //= require bootstrap-sprockets
-//= require select2
+// = require select2

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,3 +17,4 @@
 //= require_tree .
 //= require bootstrap
 //= require bootstrap-sprockets
+//= require select2

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,9 +10,9 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
-// 必ずこの順番でないとダメ
-
+ *= require_tree .
+ *= require_self
+ *= require select2
  */
-//  @import "bootstrap-sprockets";
  @import "bootstrap";
-//  @import "scss/landing-page.scss";
+ 

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -28,7 +28,7 @@ a {
 
   &:hover {
     color: #fff;
-    background-color: #000;
+    // background-color: #000;
   }
 }
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -63,7 +63,7 @@ class OrdersController < ApplicationController
   end
 
   def import
-    @orders = Order.import(params[:csv_file], params[:user_id], current_user)
+    @orders = Order.import(params[:csv_file], params[:china_buyer_id], current_user)
     redirect_to "/"
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,7 +5,7 @@ class OrdersController < ApplicationController
   # GET /orders
   # GET /orders.json
   def index
-    @orders = current_user.orders
+    @orders = current_user.japanese_retailer_orders
   end
 
   # GET /orders/1

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -63,7 +63,7 @@ class OrdersController < ApplicationController
   end
 
   def import
-    @orders = Order.import(params[:csv_file], params[:china_buyer_id], current_user)
+    @orders = Order.import(params[:csv_file], params[:chinese_buyer_id], current_user)
     redirect_to "/"
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -63,7 +63,7 @@ class OrdersController < ApplicationController
   end
 
   def import
-    @orders = Order.import(params[:csv_file], current_user)
+    @orders = Order.import(params[:csv_file], params[:user_id], current_user)
     # binding.pry
     redirect_to "/"
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -63,7 +63,8 @@ class OrdersController < ApplicationController
   end
 
   def import
-    Order.import(params[:csv_file])
+    @orders = Order.import(params[:csv_file], current_user)
+    # binding.pry
     redirect_to "/"
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -64,7 +64,6 @@ class OrdersController < ApplicationController
 
   def import
     @orders = Order.import(params[:csv_file], params[:user_id], current_user)
-    # binding.pry
     redirect_to "/"
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -63,7 +63,8 @@ class OrdersController < ApplicationController
   end
 
   def import
-    @orders = Order.import(params[:csv_file], params[:chinese_buyer_id], current_user)
+    chinese_buyer = User.find(params[:chinese_buyer_id])
+    @orders = Order.import(params[:csv_file], current_user, chinese_buyer)
     redirect_to "/"
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -11,7 +11,7 @@ class Order < ApplicationRecord
     encoding_type = NKF.guess(csv_text).to_s
     csv_utf8 = Kconv.toutf8(csv_text)
     CSV.parse(csv_utf8, headers: true, liberal_parsing: true) do |row|
-      obj = new
+      obj = find_by(trade_no: row["取引ID"]) || new
       temp = {
         quantity: row["受注数"],
         price: row["価格"],

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,7 +12,7 @@ class Order < ApplicationRecord
     csv_utf8 = Kconv.toutf8(csv_text)
     CSV.parse(csv_utf8, headers: true, liberal_parsing: true) do |row|
       obj = find_by(trade_no: row["取引ID"]) || new
-      temp = {
+      obj.assign_attributes(
         quantity: row["受注数"],
         price: row["価格"],
         trade_no: row["取引ID"],
@@ -22,19 +22,19 @@ class Order < ApplicationRecord
         phone: row["電話番号"],
         color_size: row["色・サイズ"],
         customer_remark: row["連絡事項"]
-      }
-      obj.attributes = temp.slice(*updatable_attributes)
+      )
       # 発注者（日本人）と買付担当（中国人）のidを保存
       obj.update(retailer_id: current_user.id, china_buyer_id: china_buyer_id)
       obj.save!
       # 発注者（日本人）とのリレーションを保存
-      obj.users << current_user
+      obj.users << current_user unless obj.users.include?(current_user)
       # 買付担当（中国人）とのリレーションを保存
-      obj.users << User.find(china_buyer_id)
+      china_buyer = User.find(china_buyer_id)
+      obj.users << china_buyer unless obj.users.include?(china_buyer)
     end
   end
 
-  def self.updatable_attributes
-    [:quantity,:price,:trade_no,:customer_name,:postal,:address,:phone,:color_size,:customer_remark]
-  end
+  # def self.updatable_attributes
+  #   [:quantity,:price,:trade_no,:customer_name,:postal,:address,:phone,:color_size,:customer_remark]
+  # end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,7 +6,7 @@ class Order < ApplicationRecord
   has_many :user_orders
   has_many :users, through: :user_orders
 
-  def self.import(file, user_id, current_user)
+  def self.import(file, china_buyer_id, current_user)
     csv_text = file.read
     encoding_type = NKF.guess(csv_text).to_s
     csv_utf8 = Kconv.toutf8(csv_text)
@@ -25,12 +25,12 @@ class Order < ApplicationRecord
       }
       obj.attributes = temp.slice(*updatable_attributes)
       # 発注者（日本人）と買付担当（中国人）のidを保存
-      obj.update(retailer_id: current_user.id, china_buyer_id: user_id)
+      obj.update(retailer_id: current_user.id, china_buyer_id: china_buyer_id)
       obj.save!
       # 発注者（日本人）とのリレーションを保存
       obj.users << current_user
       # 買付担当（中国人）とのリレーションを保存
-      obj.users << User.find(user_id)
+      obj.users << User.find(china_buyer_id)
     end
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,7 +6,7 @@ class Order < ApplicationRecord
   has_many :user_orders
   has_many :users, through: :user_orders
 
-  def self.import(file)
+  def self.import(file, current_user)
     csv_text = file.read
     encoding_type = NKF.guess(csv_text).to_s
     csv_utf8 = Kconv.toutf8(csv_text)
@@ -25,6 +25,7 @@ class Order < ApplicationRecord
       }
       obj.attributes = temp.slice(*updatable_attributes)
       obj.save!
+      obj.users << current_user
     end
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,8 +5,10 @@ require 'nkf'
 class Order < ApplicationRecord
   has_many :user_orders
   has_many :users, through: :user_orders
+  belongs_to :japanese_retailer, class_name: 'User'
+  belongs_to :chinese_buyer, class_name: 'User'
 
-  def self.import(file, china_buyer_id, current_user)
+  def self.import(file, chinese_buyer_id, current_user)
     csv_text = file.read
     encoding_type = NKF.guess(csv_text).to_s
     csv_utf8 = Kconv.toutf8(csv_text)
@@ -24,13 +26,13 @@ class Order < ApplicationRecord
         customer_remark: row["連絡事項"]
       )
       # 発注者（日本人）と買付担当（中国人）のidを保存
-      obj.update(retailer_id: current_user.id, china_buyer_id: china_buyer_id)
+      obj.update(japanese_retailer_id: current_user.id, chinese_buyer_id: chinese_buyer_id)
       obj.save!
       # 発注者（日本人）とのリレーションを保存
       obj.users << current_user unless obj.users.include?(current_user)
       # 買付担当（中国人）とのリレーションを保存
-      china_buyer = User.find(china_buyer_id)
-      obj.users << china_buyer unless obj.users.include?(china_buyer)
+      chinese_buyer = User.find(chinese_buyer_id)
+      obj.users << chinese_buyer unless obj.users.include?(chinese_buyer)
     end
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -8,7 +8,7 @@ class Order < ApplicationRecord
   belongs_to :japanese_retailer, class_name: 'User'
   belongs_to :chinese_buyer, class_name: 'User'
 
-  def self.import(file, chinese_buyer_id, current_user)
+  def self.import(file, japanese_retailer, chinese_buyer)
     csv_text = file.read
     encoding_type = NKF.guess(csv_text).to_s
     csv_utf8 = Kconv.toutf8(csv_text)
@@ -26,12 +26,12 @@ class Order < ApplicationRecord
         customer_remark: row["連絡事項"]
       )
       # 発注者（日本人）と買付担当（中国人）のidを保存
-      obj.update(japanese_retailer_id: current_user.id, chinese_buyer_id: chinese_buyer_id)
+      obj.update(japanese_retailer_id: japanese_retailer.id, chinese_buyer_id: chinese_buyer.id)
       obj.save!
       # 発注者（日本人）とのリレーションを保存
-      obj.users << current_user unless obj.users.include?(current_user)
+      obj.users << japanese_retailer unless obj.users.include?(japanese_retailer)
       # 買付担当（中国人）とのリレーションを保存
-      chinese_buyer = User.find(chinese_buyer_id)
+      chinese_buyer = User.find(chinese_buyer.id)
       obj.users << chinese_buyer unless obj.users.include?(chinese_buyer)
     end
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -13,7 +13,7 @@ class Order < ApplicationRecord
     encoding_type = NKF.guess(csv_text).to_s
     csv_utf8 = Kconv.toutf8(csv_text)
     CSV.parse(csv_utf8, headers: true, liberal_parsing: true) do |row|
-      obj = find_by(trade_no: row["取引ID"]) || new
+      obj = find_or_initialize_by(trade_no: row["取引ID"])
       obj.assign_attributes(
         quantity: row["受注数"],
         price: row["価格"],
@@ -23,16 +23,18 @@ class Order < ApplicationRecord
         address: row["住所"],
         phone: row["電話番号"],
         color_size: row["色・サイズ"],
-        customer_remark: row["連絡事項"]
+        customer_remark: row["連絡事項"],
+        japanese_retailer_id: japanese_retailer.id,
+        chinese_buyer_id: chinese_buyer.id
       )
       # 発注者（日本人）と買付担当（中国人）のidを保存
-      obj.update(japanese_retailer_id: japanese_retailer.id, chinese_buyer_id: chinese_buyer.id)
+      # obj.update(, )
       obj.save!
       # 発注者（日本人）とのリレーションを保存
-      obj.users << japanese_retailer unless obj.users.include?(japanese_retailer)
+      # obj.users << japanese_retailer unless obj.users.include?(japanese_retailer)
       # 買付担当（中国人）とのリレーションを保存
-      chinese_buyer = User.find(chinese_buyer.id)
-      obj.users << chinese_buyer unless obj.users.include?(chinese_buyer)
+      # chinese_buyer = User.find(chinese_buyer.id)
+      # obj.users << chinese_buyer unless obj.users.include?(chinese_buyer)
     end
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -24,9 +24,12 @@ class Order < ApplicationRecord
         customer_remark: row["連絡事項"]
       }
       obj.attributes = temp.slice(*updatable_attributes)
+      # 発注者（日本人）と買付担当（中国人）のidを保存
       obj.update(retailer_id: current_user.id, china_buyer_id: user_id)
       obj.save!
+      # 発注者（日本人）とのリレーションを保存
       obj.users << current_user
+      # 買付担当（中国人）とのリレーションを保存
       obj.users << User.find(user_id)
     end
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,7 +6,7 @@ class Order < ApplicationRecord
   has_many :user_orders
   has_many :users, through: :user_orders
 
-  def self.import(file, current_user)
+  def self.import(file, user_id, current_user)
     csv_text = file.read
     encoding_type = NKF.guess(csv_text).to_s
     csv_utf8 = Kconv.toutf8(csv_text)
@@ -24,8 +24,10 @@ class Order < ApplicationRecord
         customer_remark: row["連絡事項"]
       }
       obj.attributes = temp.slice(*updatable_attributes)
+      obj.update(retailer_id: current_user.id, china_buyer_id: user_id)
       obj.save!
       obj.users << current_user
+      obj.users << User.find(user_id)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,5 +7,7 @@ class User < ApplicationRecord
   china_buyer: 0, orderer: 1
   }
   has_many :user_orders
-  has_many :orders, through: :user_orders
+  # has_many :orders, through: :user_orders
+  has_many :japanese_retailer_orders, class_name: 'Order', :foreign_key => 'japanese_retailer_id'
+  has_many :chinese_buyer_orderss, class_name: 'Order', :foreign_key => 'chinese_buyer_id'
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,6 @@ class User < ApplicationRecord
   china_buyer: 0, orderer: 1
   }
   has_many :user_orders
-  # has_many :orders, through: :user_orders
   has_many :japanese_retailer_orders, class_name: 'Order', :foreign_key => 'japanese_retailer_id'
-  has_many :chinese_buyer_orderss, class_name: 'Order', :foreign_key => 'chinese_buyer_id'
+  has_many :chinese_buyer_orders, class_name: 'Order', :foreign_key => 'chinese_buyer_id'
 end

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -89,5 +89,5 @@
       $("#operations").submit();
     });
   });
-  $("#user_id").select2({width:'auto'});
+  $("#china_buyer_id").select2({width:'auto'});
 

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -21,13 +21,6 @@
         = link_to "設定", destroy_user_session_path, method: :delete, class: "dropdown-item"
 
 .container
-  -# .col-md-4
-  -#   .input-group
-  -#     %label.input-group-btn
-  -#       %span.btn.btn-primary
-  -#         ファイル選択
-  -#         %input{:style => "display:none", :type => "file"}/
-  -#     %input.form-control{:readonly => "readonly", :type => "text"}/
   - if current_user.account_type == "orderer"
     .col-md-6
     = form_tag import_orders_path, method: :post, multipart: true do |f|
@@ -76,6 +69,8 @@
             = ""
           %td
             = ""
+          %td
+            = ""
 
 
 :javascript
@@ -94,5 +89,5 @@
       $("#operations").submit();
     });
   });
-  $("#user_id").select2({width:300});
+  $("#user_id").select2({width:'auto'});
 

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -89,5 +89,5 @@
       $("#operations").submit();
     });
   });
-  $("#china_buyer_id").select2({width:'auto'});
+  $("#chinese_buyer_id").select2({width:'auto'});
 

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -30,7 +30,7 @@
         = button_tag 'ファイル選択', class: %i(btn-primary csv_input_btn), type: 'button', onclick: "$('#file_input').click();", class: "form-control btn btn-primary"
       .col-md-5.my-2
         買付担当：
-        = select_tag(:china_buyer_id,
+        = select_tag(:chinese_buyer_id,
             options_for_select(User.where(account_type: 0).map{ |o| [o.name + " 様", o.id] }))
       .col-md-5.my-2
         %button.btn.btn-success.btn-block{:type => "submit"} インポート

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -94,4 +94,5 @@
       $("#operations").submit();
     });
   });
-  $("#user_id").select2({width:150});
+  $("#user_id").select2({width:300});
+

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -28,15 +28,19 @@
   -#         ファイル選択
   -#         %input{:style => "display:none", :type => "file"}/
   -#     %input.form-control{:readonly => "readonly", :type => "text"}/
-
-  .col-md-6
-  = form_tag import_orders_path, method: :post, multipart: true do |f|
-    .col-md-5.my-2.search_item.input-group
-      = text_field_tag 'filename',"", id: "filename", disabled: true, class: "form-control"
-      = file_field_tag 'csv_file', id: "file_input", style: "display: none;", onchange: "file_selected($(this));", class: "form-control"
-      = button_tag 'ファイル選択', class: %i(btn-primary csv_input_btn), type: 'button', onclick: "$('#file_input').click();", class: "form-control btn btn-primary"
-    .col-md-5.my-2
-      %button.btn.btn-success.btn-block{:type => "submit"} インポート
+  - if current_user.account_type == "orderer"
+    .col-md-6
+    = form_tag import_orders_path, method: :post, multipart: true do |f|
+      .col-md-5.my-2.search_item.input-group
+        = text_field_tag 'filename',"", id: "filename", disabled: true, class: "form-control"
+        = file_field_tag 'csv_file', id: "file_input", style: "display: none;", onchange: "file_selected($(this));", class: "form-control"
+        = button_tag 'ファイル選択', class: %i(btn-primary csv_input_btn), type: 'button', onclick: "$('#file_input').click();", class: "form-control btn btn-primary"
+      .col-md-5.my-2
+        買付担当：
+        = select_tag(:user_id,
+            options_for_select(User.where(account_type: 0).map{ |o| [o.name + " 様", o.id] }))
+      .col-md-5.my-2
+        %button.btn.btn-success.btn-block{:type => "submit"} インポート
   %table.table
     %thead
       %tr
@@ -85,6 +89,9 @@
     var filename = $(file_field)[0].files[0].name;
     $("#filename").val(filename);
   }
-
-
-
+  $(function(){
+    $("#operations").change(function(){
+      $("#operations").submit();
+    });
+  });
+  $("#user_id").select2({width:150});

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -30,7 +30,7 @@
         = button_tag 'ファイル選択', class: %i(btn-primary csv_input_btn), type: 'button', onclick: "$('#file_input').click();", class: "form-control btn btn-primary"
       .col-md-5.my-2
         買付担当：
-        = select_tag(:user_id,
+        = select_tag(:china_buyer_id,
             options_for_select(User.where(account_type: 0).map{ |o| [o.name + " 様", o.id] }))
       .col-md-5.my-2
         %button.btn.btn-success.btn-block{:type => "submit"} インポート

--- a/db/migrate/20191013143850_add_user_id_to_orders.rb
+++ b/db/migrate/20191013143850_add_user_id_to_orders.rb
@@ -1,0 +1,6 @@
+class AddUserIdToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :orders, :japanese_retailer, foreign_key: {to_table: :users}
+    add_reference :orders, :chinese_buyer, foreign_key: {to_table: :users}
+  end
+end

--- a/db/migrate/20191013162010_remove_retailer_id_and_china_buyer_id_from_orders.rb
+++ b/db/migrate/20191013162010_remove_retailer_id_and_china_buyer_id_from_orders.rb
@@ -1,0 +1,10 @@
+class RemoveRetailerIdAndChinaBuyerIdFromOrders < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :orders, :retailer_id
+    remove_column :orders, :china_buyer_id
+  end
+  def down
+    add_column :orders, :retailer_id, :integer
+    add_column :orders, :china_buyer_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_08_044548) do
+ActiveRecord::Schema.define(version: 2019_10_13_162010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,8 +64,10 @@ ActiveRecord::Schema.define(version: 2019_09_08_044548) do
     t.string "retailer_remark"
     t.integer "processing_status"
     t.string "taobao_color_size"
-    t.integer "retailer_id"
-    t.integer "china_buyer_id"
+    t.bigint "japanese_retailer_id"
+    t.bigint "chinese_buyer_id"
+    t.index ["chinese_buyer_id"], name: "index_orders_on_chinese_buyer_id"
+    t.index ["japanese_retailer_id"], name: "index_orders_on_japanese_retailer_id"
   end
 
   create_table "pictures", force: :cascade do |t|
@@ -111,6 +113,8 @@ ActiveRecord::Schema.define(version: 2019_09_08_044548) do
   add_foreign_key "actual_taobao_urls", "actual_item_varieties"
   add_foreign_key "item_nos", "users"
   add_foreign_key "item_varieties", "item_nos"
+  add_foreign_key "orders", "users", column: "chinese_buyer_id"
+  add_foreign_key "orders", "users", column: "japanese_retailer_id"
   add_foreign_key "pictures", "actual_item_varieties"
   add_foreign_key "taobao_urls", "item_varieties"
   add_foreign_key "user_orders", "orders"


### PR DESCRIPTION
## 概要
インポート機能を実装しました。

### タスク
#### 自分タスク
- [x] どのcsvで検証するか決める。
- [x] インポートできないことを確認する。
- [x] ファイルによってインポートできるものとできないものがあるので、改善する。
- [x] 重複して保存されないようにする。
- [x] 中間テーブルの情報なども保存されるようにする。
- [x] 買付担当の場合は、インポート部分が表示されないようにする。
- [x] インポート時に買付担当を指定できる
  - [x] プルダウンメニュー作る
  - [x] select2を適応
  - [x] BootstrapとSelectを組み込む方法
  - [x] 組み込みでselect2を使えるようにする。
  - [x] 幅の調整
  - [x] 買付担当（中国人）のセレクトボックス追加
  - [x] 買付担当（中国人）を注文に紐付ける
#### コードレビューの修正点
- [x] find_or_initialize_byに修正する
- [x] update の方は assign_attributes に置き換えて save の時だけDBへリクエストするようにする。
- [x] UserOrderテーブル不要？

### インポートサンプルファイル
[buyerorder-20191004.csv.zip](https://github.com/fukadashigeru/china_trade_system/files/3700177/buyerorder-20191004.csv.zip)
