### PR TITLE
買付先回りのテーブル追加・モデル追加

### DIFF
--- a/app/assets/javascripts/item_sets.coffee
+++ b/app/assets/javascripts/item_sets.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,3 +21,5 @@
 @import "./reset";
 @import "./order";
 @import "./order_manual_inputs";
+@import "./layout";
+@import "./item_sets";

--- a/app/assets/stylesheets/item_sets.scss
+++ b/app/assets/stylesheets/item_sets.scss
@@ -1,5 +1,23 @@
 #item_sets_modal {
-  .first_canditate_select {
+  .first_candidate_select {
     width: 80px;
   }
+}
+
+// input[type=checkbox] {
+//   transform: scale(1.2);
+// }
+
+// input[type=checkbox] {
+//   -ms-transform: scale(1.5, 1.5);
+//   -webkit-transform: scale(1.5, 1.5);
+//   transform: scale(1.5, 1.5);
+// }
+
+option:first-child{
+  background:red;
+  color:#fff;
+}
+option:nth-child(2){
+  background:orange;
 }

--- a/app/assets/stylesheets/item_sets.scss
+++ b/app/assets/stylesheets/item_sets.scss
@@ -1,0 +1,5 @@
+#item_sets_modal {
+  .first_canditate_select {
+    width: 80px;
+  }
+}

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1,0 +1,4 @@
+.button-fixed-right {
+  position: absolute;
+  right: 10px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  # add_flash_types :success, :info, :warning, :danger
+
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/item_sets_controller.rb
+++ b/app/controllers/item_sets_controller.rb
@@ -8,41 +8,12 @@ class ItemSetsController < ApplicationController
     item_set = current_user.item_sets.find(params[:id])
     begin
       ActiveRecord::Base.transaction do
-        item_set.processing_item_units_and_taobao_urls(taobao_url_params, first_candidate_params, have_stock_params, current_user)
-        # taobao_url_params.keys.each do |i|
-        #   taobao_url_params[i].keys.each do |j|
-        #     if j == "0"
-        #       item_unit = item_set.item_units.create
-        #     else
-        #       item_unit = item_set.item_units.find(j.to_i)
-        #     end
-        #     taobao_url_params[i][j].keys.each do |k|
-        #       taobao_url_params[i][j][k].keys.each do |l|
-        #         taobao_url_url = taobao_url_params[i][j][k][l]
-        #         ## TODO 空欄でも削除とかせな
-        #         next unless taobao_url_params[i][j][k][l].present?
-        #         if l == "0"
-        #           taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
-        #           item_unit.item_unit_taobao_urls.create(taobao_url_id: taobao_url.id)
-        #         else
-        #           taobao_url = item_unit.taobao_urls.find(l.to_i)
-        #           item_unit_taobao_url = ItemUnitTaobaoUrl.find_by(item_unit_id: j.to_i , taobao_url_id: l.to_i)
-        #           if taobao_url.item_units.length > 1
-        #             taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
-        #             item_unit_taobao_url.update(taobao_url_id: taobao_url.id)
-        #           else
-        #             taobao_url.update(url: taobao_url_url)
-        #           end
-        #         end
-        #         if k == first_candidate_params
-        #           binding.pry
-        #           item_unit.update(first_candidate_id: taobao_url.id)
-        #         end
-        #         taobao_url.update(is_have_stock: have_stock_params[k].to_i)
-        #       end
-        #     end
-        #   end
-        # end
+        item_set.processing_item_units_and_taobao_urls(
+          taobao_url_params,
+          first_candidate_params,
+          have_stock_params,
+          current_user
+        )
       end
       flash[:success] = "更新できました"
       redirect_to root_path

--- a/app/controllers/item_sets_controller.rb
+++ b/app/controllers/item_sets_controller.rb
@@ -1,0 +1,57 @@
+class ItemSetsController < ApplicationController
+  def edit
+    @item_set = current_user.item_sets.find(params[:id])
+    @item_units_and_taobao_urls_hash = @item_set.build_item_units_and_taobao_urls
+  end
+
+  def update
+    item_set = current_user.item_sets.find(params[:id])
+    begin
+      ActiveRecord::Base.transaction do
+        taobao_url_params.keys.each do |i|
+          taobao_url_params[i].keys.each do |j|
+            if j == "0"
+              item_unit = item_set.item_units.create
+            else
+              item_unit = item_set.item_units.find(j.to_i)
+            end
+            taobao_url_params[i][j].keys.each do |k|
+              taobao_url_params[i][j][k].keys.each do |l|
+                taobao_url_url = taobao_url_params[i][j][k][l]
+                ## TODO 空欄でも削除とかせな
+                next unless taobao_url_params[i][j][k][l].present?
+                if l == "0"
+                  taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
+                  item_unit.item_unit_taobao_urls.create(taobao_url_id: taobao_url.id)
+                else
+                  taobao_url = item_unit.taobao_urls.find(l.to_i)
+                  item_unit_taobao_url = ItemUnitTaobaoUrl.find_by(item_unit_id: j.to_i , taobao_url_id: l.to_i)
+                  if taobao_url.item_units.length > 1
+                    taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
+                    item_unit_taobao_url.update(taobao_url_id: taobao_url.id)
+                  else
+                    taobao_url.update(url: taobao_url_url)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+      flash[:success] = "更新できました"
+      redirect_to root_path
+    rescue
+      flash[:danger] = "更新に失敗しました"
+      redirect_to root_path
+    end
+  end
+
+  def search
+    @item_set = ItemSet.find_or_initialize_by(user_id: current_user.id, item_no: params[:item_no], item_no_category: params[:item_no_category])
+  end
+
+  private
+    def taobao_url_params
+      params.require(:"taobao_url")
+    end
+end

--- a/app/controllers/item_sets_controller.rb
+++ b/app/controllers/item_sets_controller.rb
@@ -33,9 +33,8 @@ class ItemSetsController < ApplicationController
     end
 
     def first_candidate_params
-      ## チェックボックスが必ずどれか入れる仕様になったら、下記のコードに変更
-      # params.require(:"first_candidate_select").keys.first
-      params[:"first_candidate_select"]&.keys&.first
+      # params.require(:"first_candidate_select")
+      params[:"first_candidate_select"]
     end
 
     def have_stock_params

--- a/app/controllers/item_sets_controller.rb
+++ b/app/controllers/item_sets_controller.rb
@@ -8,40 +8,41 @@ class ItemSetsController < ApplicationController
     item_set = current_user.item_sets.find(params[:id])
     begin
       ActiveRecord::Base.transaction do
-        taobao_url_params.keys.each do |i|
-          taobao_url_params[i].keys.each do |j|
-            if j == "0"
-              item_unit = item_set.item_units.create
-            else
-              item_unit = item_set.item_units.find(j.to_i)
-            end
-            taobao_url_params[i][j].keys.each do |k|
-              taobao_url_params[i][j][k].keys.each do |l|
-                taobao_url_url = taobao_url_params[i][j][k][l]
-                ## TODO 空欄でも削除とかせな
-                next unless taobao_url_params[i][j][k][l].present?
-                if l == "0"
-                  taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
-                  item_unit.item_unit_taobao_urls.create(taobao_url_id: taobao_url.id)
-                else
-                  taobao_url = item_unit.taobao_urls.find(l.to_i)
-                  item_unit_taobao_url = ItemUnitTaobaoUrl.find_by(item_unit_id: j.to_i , taobao_url_id: l.to_i)
-                  if taobao_url.item_units.length > 1
-                    taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
-                    item_unit_taobao_url.update(taobao_url_id: taobao_url.id)
-                  else
-                    taobao_url.update(url: taobao_url_url)
-                  end
-                end
-                if k == first_candidate_params
-                  item_unit.update(first_candidate_id: taobao_url.id)
-                end
-                # binding.pry
-                taobao_url.update(is_have_stock: have_stock_params[k].to_i)
-              end
-            end
-          end
-        end
+        item_set.processing_item_units_and_taobao_urls(taobao_url_params, first_candidate_params, have_stock_params, current_user)
+        # taobao_url_params.keys.each do |i|
+        #   taobao_url_params[i].keys.each do |j|
+        #     if j == "0"
+        #       item_unit = item_set.item_units.create
+        #     else
+        #       item_unit = item_set.item_units.find(j.to_i)
+        #     end
+        #     taobao_url_params[i][j].keys.each do |k|
+        #       taobao_url_params[i][j][k].keys.each do |l|
+        #         taobao_url_url = taobao_url_params[i][j][k][l]
+        #         ## TODO 空欄でも削除とかせな
+        #         next unless taobao_url_params[i][j][k][l].present?
+        #         if l == "0"
+        #           taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
+        #           item_unit.item_unit_taobao_urls.create(taobao_url_id: taobao_url.id)
+        #         else
+        #           taobao_url = item_unit.taobao_urls.find(l.to_i)
+        #           item_unit_taobao_url = ItemUnitTaobaoUrl.find_by(item_unit_id: j.to_i , taobao_url_id: l.to_i)
+        #           if taobao_url.item_units.length > 1
+        #             taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
+        #             item_unit_taobao_url.update(taobao_url_id: taobao_url.id)
+        #           else
+        #             taobao_url.update(url: taobao_url_url)
+        #           end
+        #         end
+        #         if k == first_candidate_params
+        #           binding.pry
+        #           item_unit.update(first_candidate_id: taobao_url.id)
+        #         end
+        #         taobao_url.update(is_have_stock: have_stock_params[k].to_i)
+        #       end
+        #     end
+        #   end
+        # end
       end
       flash[:success] = "更新できました"
       redirect_to root_path
@@ -63,7 +64,7 @@ class ItemSetsController < ApplicationController
     def first_candidate_params
       ## チェックボックスが必ずどれか入れる仕様になったら、下記のコードに変更
       # params.require(:"first_candidate_select").keys.first
-      params[:"first_candidate_select"].keys.first
+      params[:"first_candidate_select"]&.keys&.first
     end
 
     def have_stock_params

--- a/app/controllers/item_sets_controller.rb
+++ b/app/controllers/item_sets_controller.rb
@@ -33,6 +33,11 @@ class ItemSetsController < ApplicationController
                     taobao_url.update(url: taobao_url_url)
                   end
                 end
+                if k == first_candidate_params
+                  item_unit.update(first_candidate_id: taobao_url.id)
+                end
+                # binding.pry
+                taobao_url.update(is_have_stock: have_stock_params[k].to_i)
               end
             end
           end
@@ -53,5 +58,15 @@ class ItemSetsController < ApplicationController
   private
     def taobao_url_params
       params.require(:"taobao_url")
+    end
+
+    def first_candidate_params
+      ## チェックボックスが必ずどれか入れる仕様になったら、下記のコードに変更
+      # params.require(:"first_candidate_select").keys.first
+      params[:"first_candidate_select"].keys.first
+    end
+
+    def have_stock_params
+      params.require(:"have_stock")
     end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -24,7 +24,6 @@ class OrdersController < ApplicationController
 
   def edit
     @order = current_user.japanese_retailer_orders.find(params[:id])
-    # @order.pictures.new()
   end
 
   # POST /orders

--- a/app/helpers/item_sets_helper.rb
+++ b/app/helpers/item_sets_helper.rb
@@ -1,0 +1,2 @@
+module ItemSetsHelper
+end

--- a/app/models/item_no.rb
+++ b/app/models/item_no.rb
@@ -1,3 +1,0 @@
-class ItemNo < ApplicationRecord
-  belongs_to :user
-end

--- a/app/models/item_set.rb
+++ b/app/models/item_set.rb
@@ -11,7 +11,7 @@ class ItemSet < ApplicationRecord
       [[item_unit, 3.times.map{ item_unit.taobao_urls.build }]].to_h
     else
       #TODO: 間違ってるかも
-      item_units.map do |item_unit|
+      item_units.order(:id).map do |item_unit|
         # taobao_urls_array = item_unit.taobao_urls.map do |taobao_url|
         taobao_urls_array = item_unit.item_unit_taobao_urls.order(:id).map(&:taobao_url).map do |taobao_url|
           taobao_url
@@ -56,10 +56,15 @@ class ItemSet < ApplicationRecord
                 end
               else
                 if taobao_url_url.present?
-                  taobao_url.update(url: taobao_url_url)
+                  other_taobao_url = current_user.taobao_urls.find_by(url: taobao_url_url)
+                  if other_taobao_url&.id != l.to_i
+                    taobao_url.destroy if taobao_url.item_units.length > 1
+                    taobao_url = other_taobao_url
+                  else
+                    taobao_url.update(url: taobao_url_url)
+                  end
                   taobao_url_ids_included_in_params << taobao_url.id
                 else
-                  # item_unit_taobao_url.destroy
                   taobao_url.destroy
                 end
               end

--- a/app/models/item_set.rb
+++ b/app/models/item_set.rb
@@ -24,7 +24,7 @@ class ItemSet < ApplicationRecord
   end
 
   def processing_item_units_and_taobao_urls(taobao_url_params, first_candidate_params, have_stock_params, current_user)
-    ids_included_in_params = Array.new
+    item_unit_ids_included_in_params = Array.new
     taobao_url_params.keys.each do |i|
       taobao_url_params[i].keys.each do |j|
         if j == "0"
@@ -32,6 +32,8 @@ class ItemSet < ApplicationRecord
         else
           item_unit = item_units.find(j.to_i)
         end
+        item_unit_ids_included_in_params << item_unit.id
+        taobao_url_ids_included_in_params = Array.new
         taobao_url_params[i][j].keys.each do |k|
           taobao_url_params[i][j][k].keys.each do |l|
             taobao_url_url = taobao_url_params[i][j][k][l]
@@ -40,7 +42,7 @@ class ItemSet < ApplicationRecord
               next unless taobao_url_url.present?
               taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
               item_unit.item_unit_taobao_urls.create(taobao_url_id: taobao_url.id)
-              ids_included_in_params << taobao_url.id
+              taobao_url_ids_included_in_params << taobao_url.id
             else
               taobao_url = item_unit.taobao_urls.find(l.to_i)
               item_unit_taobao_url = ItemUnitTaobaoUrl.find_by(item_unit_id: j.to_i , taobao_url_id: l.to_i)
@@ -48,14 +50,14 @@ class ItemSet < ApplicationRecord
                 if taobao_url_url.present?
                   taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
                   item_unit_taobao_url.update(taobao_url_id: taobao_url.id)
-                  ids_included_in_params << taobao_url.id
+                  taobao_url_ids_included_in_params << taobao_url.id
                 else
                   item_unit_taobao_url.destroy
                 end
               else
                 if taobao_url_url.present?
                   taobao_url.update(url: taobao_url_url)
-                  ids_included_in_params << taobao_url.id
+                  taobao_url_ids_included_in_params << taobao_url.id
                 else
                   # item_unit_taobao_url.destroy
                   taobao_url.destroy
@@ -63,18 +65,28 @@ class ItemSet < ApplicationRecord
               end
             end
             ## 第一候補をitem_unitのfirst_candidate_idに登録する
-            if k == first_candidate_params
-              item_unit.update(first_candidate_id: taobao_url.id)
+            if first_candidate_params
+              if k == first_candidate_params[i]&.keys&.first
+                item_unit.update(first_candidate_id: taobao_url.id)
+              end
             end
             # 在庫の有無を変更
             if taobao_url_url.present?
-              taobao_url.update(is_have_stock: have_stock_params[k].to_i)
+              taobao_url.update(is_have_stock: have_stock_params[i][k].to_i)
             end
           end
         end
+        ##　item_unit単位でどれにもチェックが入ってないときに、first_candidate_idをnilにする
+        ### 他のやつのもふくめてないとき
+        if first_candidate_params.nil?
+          item_unit.update(first_candidate_id: nil)
+        ### 該当するのだけないとき
+        elsif !first_candidate_params[i]
+          item_unit.update(first_candidate_id: nil)
+        end
         #削除処理
-        removed_ids = item_unit.taobao_urls.ids - ids_included_in_params
-        removed_ids.each do |i|
+        removed_taobao_url_ids = item_unit.taobao_urls.ids - taobao_url_ids_included_in_params
+        removed_taobao_url_ids.each do |i|
           removed_taobao_url = current_user.taobao_urls.find(i)
           if removed_taobao_url.item_units.length > 1
             item_unit_taobao_url = ItemUnitTaobaoUrl.find_by(item_unit_id: item_unit.id, taobao_url_id: i)
@@ -87,6 +99,11 @@ class ItemSet < ApplicationRecord
           item_unit.destroy
         end
       end
+    end
+    removed_item_unit_ids = item_units.ids - item_unit_ids_included_in_params
+    removed_item_unit_ids.each do |i|
+      removed_item_unit = item_units.find(i)
+      removed_item_unit.destroy
     end
   end
 end

--- a/app/models/item_set.rb
+++ b/app/models/item_set.rb
@@ -1,0 +1,24 @@
+class ItemSet < ApplicationRecord
+  belongs_to :user
+  has_many :orders
+  has_many :item_units
+
+  enum item_no_category: { unspecified: 0, buyma: 1, amazon: 2 }
+
+  def build_item_units_and_taobao_urls
+    if item_units.empty?
+      item_unit = item_units.build
+      [[item_unit, 3.times.map{ item_unit.taobao_urls.build }]].to_h
+    else
+      #TODO: 間違ってるかも
+      item_units.map do |item_unit|
+        taobao_urls_array = item_unit.taobao_urls.map do |taobao_url|
+          taobao_url
+        end
+        n = 3 - item_unit.taobao_urls.length
+        n.times{ taobao_urls_array << item_unit.taobao_urls.build }
+        [item_unit, taobao_urls_array]
+      end.to_h
+    end
+  end
+end

--- a/app/models/item_set.rb
+++ b/app/models/item_set.rb
@@ -57,9 +57,13 @@ class ItemSet < ApplicationRecord
               else
                 if taobao_url_url.present?
                   other_taobao_url = current_user.taobao_urls.find_by(url: taobao_url_url)
-                  if other_taobao_url&.id != l.to_i
-                    taobao_url.destroy if taobao_url.item_units.length > 1
-                    taobao_url = other_taobao_url
+                  if other_taobao_url
+                    if other_taobao_url&.id != l.to_i
+                      taobao_url.destroy if taobao_url.item_units.length > 1
+                      taobao_url = other_taobao_url
+                    else
+                      taobao_url.update(url: taobao_url_url)
+                    end
                   else
                     taobao_url.update(url: taobao_url_url)
                   end

--- a/app/models/item_set.rb
+++ b/app/models/item_set.rb
@@ -21,4 +21,40 @@ class ItemSet < ApplicationRecord
       end.to_h
     end
   end
+
+  def processing_item_units_and_taobao_urls(taobao_url_params, first_candidate_params, have_stock_params, current_user)
+    taobao_url_params.keys.each do |i|
+      taobao_url_params[i].keys.each do |j|
+        if j == "0"
+          item_unit = item_units.create
+        else
+          item_unit = item_units.find(j.to_i)
+        end
+        taobao_url_params[i][j].keys.each do |k|
+          taobao_url_params[i][j][k].keys.each do |l|
+            taobao_url_url = taobao_url_params[i][j][k][l]
+            ## TODO 空欄でも削除とかせな
+            next unless taobao_url_params[i][j][k][l].present?
+            if l == "0"
+              taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
+              item_unit.item_unit_taobao_urls.create(taobao_url_id: taobao_url.id)
+            else
+              taobao_url = item_unit.taobao_urls.find(l.to_i)
+              item_unit_taobao_url = ItemUnitTaobaoUrl.find_by(item_unit_id: j.to_i , taobao_url_id: l.to_i)
+              if taobao_url.item_units.length > 1
+                taobao_url = current_user.taobao_urls.find_or_create_by(url: taobao_url_url)
+                item_unit_taobao_url.update(taobao_url_id: taobao_url.id)
+              else
+                taobao_url.update(url: taobao_url_url)
+              end
+            end
+            if k == first_candidate_params
+              item_unit.update(first_candidate_id: taobao_url.id)
+            end
+            taobao_url.update(is_have_stock: have_stock_params[k].to_i)
+          end
+        end
+      end
+    end
+  end
 end

--- a/app/models/item_unit.rb
+++ b/app/models/item_unit.rb
@@ -1,6 +1,6 @@
 class ItemUnit < ApplicationRecord
   belongs_to :item_set
   belongs_to :first_candidate, class_name: 'TaobaoUrl', foreign_key: :first_candidate_id, optional: true
-  has_many :item_unit_taobao_urls, inverse_of: :item_unit
+  has_many :item_unit_taobao_urls
   has_many :taobao_urls, through: :item_unit_taobao_urls
 end

--- a/app/models/item_unit.rb
+++ b/app/models/item_unit.rb
@@ -1,6 +1,6 @@
 class ItemUnit < ApplicationRecord
   belongs_to :item_set
   belongs_to :first_candidate, class_name: 'TaobaoUrl', foreign_key: :first_candidate_id, optional: true
-  has_many :item_unit_taobao_urls
+  has_many :item_unit_taobao_urls, dependent: :destroy
   has_many :taobao_urls, through: :item_unit_taobao_urls
 end

--- a/app/models/item_unit.rb
+++ b/app/models/item_unit.rb
@@ -1,0 +1,5 @@
+class ItemUnit < ApplicationRecord
+  belongs_to :item_set
+  has_many :item_unit_taobao_urls
+  has_many :taobao_urls, through: :item_unit_taobao_urls
+end

--- a/app/models/item_unit.rb
+++ b/app/models/item_unit.rb
@@ -1,5 +1,6 @@
 class ItemUnit < ApplicationRecord
   belongs_to :item_set
-  has_many :item_unit_taobao_urls
+  belongs_to :first_candidate, class_name: 'TaobaoUrl', foreign_key: :first_candidate_id, optional: true
+  has_many :item_unit_taobao_urls, inverse_of: :item_unit
   has_many :taobao_urls, through: :item_unit_taobao_urls
 end

--- a/app/models/item_unit_taobao_url.rb
+++ b/app/models/item_unit_taobao_url.rb
@@ -1,4 +1,5 @@
 class ItemUnitTaobaoUrl < ApplicationRecord
   belongs_to :item_unit
   belongs_to :taobao_url
+  # validates :item_unit_id, :uniqueness => {:scope => :taobao_url_id}
 end

--- a/app/models/item_unit_taobao_url.rb
+++ b/app/models/item_unit_taobao_url.rb
@@ -1,0 +1,4 @@
+class ItemUnitTaobaoUrl < ApplicationRecord
+  belongs_to :item_unit
+  belongs_to :taobao_url
+end

--- a/app/models/item_variety.rb
+++ b/app/models/item_variety.rb
@@ -1,3 +1,0 @@
-class ItemVariety < ApplicationRecord
-  belongs_to :item_no
-end

--- a/app/models/taobao_url.rb
+++ b/app/models/taobao_url.rb
@@ -1,7 +1,8 @@
 class TaobaoUrl < ApplicationRecord
   belongs_to :user
-  has_many :item_unit_taobao_urls
+  has_many :item_unit_taobao_urls, inverse_of: :taobao_url
   has_many :item_units, through: :item_unit_taobao_urls
-
+  has_many :item_units_where_i_am_first_candidate, class_name: 'ItemUnit', foreign_key: :first_candidate_id, dependent: :nullify
   enum is_have_stock: { have_stock: 0, not_have_stock: 1 }
+  validates :is_have_stock, presence: true
 end

--- a/app/models/taobao_url.rb
+++ b/app/models/taobao_url.rb
@@ -1,3 +1,5 @@
 class TaobaoUrl < ApplicationRecord
-  belongs_to :item_variety
+  belongs_to :user
+  has_many :item_unit_taobao_urls
+  has_many :item_units, through: :item_unit_taobao_urls
 end

--- a/app/models/taobao_url.rb
+++ b/app/models/taobao_url.rb
@@ -2,4 +2,6 @@ class TaobaoUrl < ApplicationRecord
   belongs_to :user
   has_many :item_unit_taobao_urls
   has_many :item_units, through: :item_unit_taobao_urls
+
+  enum is_have_stock: { have_stock: 0, not_have_stock: 1 }
 end

--- a/app/models/taobao_url.rb
+++ b/app/models/taobao_url.rb
@@ -1,6 +1,6 @@
 class TaobaoUrl < ApplicationRecord
   belongs_to :user
-  has_many :item_unit_taobao_urls, inverse_of: :taobao_url
+  has_many :item_unit_taobao_urls, dependent: :destroy #TaobaoUrlが削除されたら、子要素のItemUnitTaobaoUrlも削除する
   has_many :item_units, through: :item_unit_taobao_urls
   has_many :item_units_where_i_am_first_candidate, class_name: 'ItemUnit', foreign_key: :first_candidate_id, dependent: :nullify
   enum is_have_stock: { have_stock: 0, not_have_stock: 1 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,5 +9,7 @@ class User < ApplicationRecord
   has_many :user_orders
   has_many :japanese_retailer_orders, class_name: 'Order', :foreign_key => 'japanese_retailer_id'
   has_many :chinese_buyer_orders, class_name: 'Order', :foreign_key => 'chinese_buyer_id'
+  has_many :item_sets
   accepts_nested_attributes_for :japanese_retailer_orders
+  has_many :taobao_urls
 end

--- a/app/views/item_sets/_edit.html.haml
+++ b/app/views/item_sets/_edit.html.haml
@@ -27,41 +27,131 @@
               = link_to @item_set.shop_url, @item_set.shop_url, :target=>["_blank"]
           %br
           .h4 買付先URL
-          .row
-            .col
-              %table.table.table-bordered
-                %thead.thead-light
-                  %tr
-                    %th.first_canditate_select 第一候補
-                    %th URL
-                    %th 在庫
-                %tbody#item_sets_table
-                  - @item_units_and_taobao_urls_hash.keys.each_with_index do |item_unit, i|
-                    - @item_units_and_taobao_urls_hash[item_unit].each_with_index do |taobao_url, j|
+          - @item_units_and_taobao_urls_hash.keys.each_with_index do |item_unit, i|
+            .row
+              .col
+                %table.table.table-bordered
+                  %thead.thead-light
+                    %tr
+                      %th.first_candidate_select 第一候補
+                      %th URL
+                      %th 在庫
+                  %tbody.item_unit_tbody
+                    - @item_units_and_taobao_urls_hash[item_unit].each_with_index do |taobao_url, k|
                       %tr
-                        %td.pl-5.pt-4= check_box_tag "to_do", true, false, class: "form-check submit_check_box"
+                        - check_box_true_or_false = item_unit.first_candidate_id == taobao_url.id && item_unit.first_candidate_id.present? ? true : false
+                        %td.pl-5.pt-4= check_box_tag "first_candidate_select[#{k}]", true, check_box_true_or_false, class: "form-check submit_check_box"
                         %td
                           .input-group
-                            = text_field_tag "taobao_url[#{i}][#{item_unit.id.to_i}][#{j}][#{taobao_url.id.to_i}]", taobao_url.url, class: "form-control taobao_url_input"
+                            = text_field_tag "taobao_url[#{i}][#{item_unit.id.to_i}][#{k}][#{taobao_url.id.to_i}]", taobao_url.url, class: "form-control taobao_url_input"
                             .input-group-append
                               %span#basic-addon2.input-group-text
-                                = link_to taobao_url.url, :target=>["_blank"], class: "fontawsome_taobao_url_link" do
+                                - taobao_url_url = taobao_url.url.nil? ? '' : taobao_url.url
+                                = link_to taobao_url_url, :target=>["_blank"], class: "fontawsome_taobao_url_link" do
                                   %i.fas.fa-external-link-alt
                         %td
+                          - have_stock_options = TaobaoUrl.is_have_stocks.map {|key, value| [ I18n.t("activerecord.attributes.taobao_url.is_have_stock.#{key}", locale: :ja), value]}
+                          - have_stock_class = taobao_url.is_have_stock == "have_stock" ? "have_stock form-control" : "have_stock form-control bg-secondary text-white"
+                          = select_tag "have_stock[#{k}]", options_for_select(have_stock_options, selected: taobao_url.is_have_stock_before_type_cast), class: have_stock_class
+                -# .d-inline
+                .btn.btn-sm.btn-success.text-center.add-input-btn
+                  %i.far.fa-arrow-alt-circle-up
+                  買付先URL追加
+
         %br
         .modal-footer
           = submit_tag "保存", class: "btn btn-primary pull-right"
 
-
 :javascript
   $(function() {
+    addTrFunction();
+    recursiveAllFunction();
+  });
+  // 再起をする必要がある関数群
+  function recursiveAllFunction() {
     $('.taobao_url_input').change(function(){
       resetTaobaoUrlLink();
     })
-  });
+    $('.form-check').on('click', function(e){
+      var $this_form_check = $(e.target);
+      var $this_item_unit_tbody = $(e.target).closest('.item_unit_tbody');
+      //console.log($this_item_unit_tbody);
+      var $all_form_checks = $this_item_unit_tbody.find('.form-check');
+      // すべてのチェックボックスのチェックを外す
+      $all_form_checks.prop('checked', false);
+      // 今回のチェックボックスのチェックを入れる
+      $this_form_check.prop('checked', true); 
+    })
+    $('.have_stock').change(function(e) {
+      var $this_select_tag = $(e.target);
+      var n = $this_select_tag.children('option:selected').val();
+      switch (n) {
+        case '0':
+          $this_select_tag.removeClass('bg-secondary text-white');
+          break;
+        case '1':
+          $this_select_tag.addClass('bg-secondary text-white');
+          break;
+      }
+    })
+  }
   function resetTaobaoUrlLink() {
-    $('#item_sets_table tr').each(function(index, tr_element) {
+    $('.item_unit_tbody tr').each(function(index, tr_element) {
       var taobao_url = $(tr_element).find('.taobao_url_input').val();
       $(tr_element).find('.fontawsome_taobao_url_link').attr('href', taobao_url);
     })
   }
+  //TaobaoUrlを入力するフォームの1行を追加する関数
+  function addTrFunction() {
+    $('.add-input-btn').on('click', function(e){
+      $add_btn = $(e.target);
+      $this_table = $add_btn.prev('.table');
+      $this_tbody = $this_table.children('.item_unit_tbody');
+      console.log($this_tbody);
+      $this_table_last_tr = $this_table.find('tr:last');
+      $this_table_submit_check_box = $this_table_last_tr.find('.submit_check_box');
+      $last_taobao_url_input = $this_table_last_tr.find('.taobao_url_input');
+      // 最後のcheckboxのnameから追加のcheckboxのnameを作る
+      var $this_table_submit_check_box_name = $this_table_submit_check_box.attr('name');
+      var $this_table_submit_check_box_name_slice = $this_table_submit_check_box_name.slice(0, -1);
+      var $this_table_submit_check_box_name_split_array = $this_table_submit_check_box_name_slice.split('[');
+      var last_check_box_id = $this_table_submit_check_box_name_split_array[1];
+      var new_tr_id = String(Number(last_check_box_id) + 1);
+      // 最後のinputのnameから追加のinputのnameを作る
+      var last_taobao_url_input_name = $last_taobao_url_input.attr('name');
+      var last_taobao_url_input_name_split_array = last_taobao_url_input_name.split('][');
+      var new_taobao_url_input_name_split_array = last_taobao_url_input_name_split_array;
+      new_taobao_url_input_name_split_array[2] = String(Number(last_taobao_url_input_name_split_array[2]) + 1);
+      new_taobao_url_input_name_split_array[3] = '0]'
+      var new_taobao_url_input_name = new_taobao_url_input_name_split_array.join('][');
+      // 最後のinputのideから追加のinputのideを作る
+      var last_taobao_url_input_id = $last_taobao_url_input.attr('id');
+      var last_taobao_url_input_id_split_array = last_taobao_url_input_id.split('_');
+      var new_taobao_url_input_id_split_array = last_taobao_url_input_id_split_array;
+      new_taobao_url_input_id_split_array[4] = String(Number(last_taobao_url_input_id_split_array[4]) + 1);
+      new_taobao_url_input_id_split_array[5] = "0";
+      var new_taobao_url_input_id = new_taobao_url_input_id_split_array.join('_');
+      var add_new_input_html =`
+        <tr>
+        <td class="pl-5 pt-4"><input type="checkbox" name="first_candidate_select[${new_tr_id}]" id="first_candidate_select_${new_tr_id}" value="true" class="form-check submit_check_box"></td>
+        <td>
+        <div class="input-group">
+        <input type="text" name="${new_taobao_url_input_name}" id="${new_taobao_url_input_id}" class="form-control taobao_url_input">
+        <div class="input-group-append">
+        <span class="input-group-text" id="basic-addon2">
+        <a target="_blank" class="fontawsome_taobao_url_link" href=""><i class="fas fa-external-link-alt"></i>
+        </a></span>
+        </div>
+        </div>
+        </td>
+        <td>
+        <select name="have_stock[${new_tr_id}]" id="have_stock_${new_tr_id}" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
+        <option value="1">在庫無し</option></select>
+        </td>
+        </tr>
+      `
+      $this_tbody.append(add_new_input_html);
+      return recursiveAllFunction();
+    })
+  }
+

--- a/app/views/item_sets/_edit.html.haml
+++ b/app/views/item_sets/_edit.html.haml
@@ -26,24 +26,30 @@
               
           %br
           .h4 買付先URL
-          - @item_units_and_taobao_urls_hash.keys.each_with_index do |item_unit, i|
-            .row.mx-2
-              .col.mb-5
-                .h5
-                  = "商品 #{i + 1}"
-                .d-block.ml-2
+          .item_units
+            - @item_units_and_taobao_urls_hash.keys.each_with_index do |item_unit, i|
+              .row.mx-2.item-row
+                .col.mb-5
+                  .h5
+                    .d-inline.item_unit_title
+                      = ""
+                    -# - if i != 0
+                    .btn.btn-sm.btn-outline-danger.item_unit_remove_btn
+                      %i.fas.fa-trash-alt
                   %table.table.table-bordered
                     %thead.thead-light
                       %tr
                         %th.first_candidate_select 第1候補
                         %th URL
                         %th 在庫
+                        %th 削除
                     %tbody.item_unit_tbody
                       - @item_units_and_taobao_urls_hash[item_unit].each_with_index do |taobao_url, k|
                         %tr
                           - check_box_true_or_false = item_unit.first_candidate_id == taobao_url.id && item_unit.first_candidate_id.present? ? true : false
-                          %td.pl-5.pt-4= check_box_tag "first_candidate_select[#{k}]", true, check_box_true_or_false, class: "form-check submit_check_box"
-                          %td
+                          %td.text-center.align-middle
+                            = check_box_tag "first_candidate_select[#{k}]", true, check_box_true_or_false, class: "submit_check_box"
+                          %td.text-center.align-middle
                             .input-group
                               = text_field_tag "taobao_url[#{i}][#{item_unit.id.to_i}][#{k}][#{taobao_url.id.to_i}]", taobao_url.url, class: "form-control taobao_url_input"
                               .input-group-append
@@ -51,16 +57,20 @@
                                   - taobao_url_url = taobao_url.url.nil? ? '' : taobao_url.url
                                   = link_to taobao_url_url, :target=>["_blank"], class: "fontawsome_taobao_url_link" do
                                     %i.fas.fa-external-link-alt
-                          %td
+                          %td.text-center.align-middle
                             - have_stock_options = TaobaoUrl.is_have_stocks.map {|key, value| [ I18n.t("activerecord.attributes.taobao_url.is_have_stock.#{key}", locale: :ja), value]}
                             - have_stock_class = taobao_url.is_have_stock == "have_stock" ? "have_stock form-control" : "have_stock form-control bg-secondary text-white"
                             = select_tag "have_stock[#{k}]", options_for_select(have_stock_options, selected: taobao_url.is_have_stock_before_type_cast), class: have_stock_class
-                  .d-block{style: 'margin-left: 80px; margin-right: 197px;'}
+                          %td.text-center.align-middle
+                            .btn.btn-sm.btn-outline-danger.tr_remove_btn
+                              %i.fas.fa-trash-alt
+
+                  .d-block{style: 'margin-left: 80px; margin-right: 250px;'}
                     .btn.btn-sm.btn-outline-success.btn-block.text-center.add-input-btn
                       %i.fas.fa-arrow-alt-circle-up.fa-lg
                       買付先URL追加
           .d-block
-            .btn.btn-sm.btn-outline-warning.text-center.add-input-btn{title: 'セット商品の場合などで登録したい場合は、商品を追加してください', data: { toggle: "tooltip", placement: "top", delay: { "show": 200, "hide": 100 }}}
+            .btn.btn-sm.btn-outline-warning.text-center.add-item-unit-btn{title: 'セット商品の場合などで複数商品を登録したい時に、商品を追加してください', data: { toggle: "tooltip", placement: "top", delay: { "show": 200, "hide": 100 }}}
               商品追加
               %i.fas.fa-long-arrow-alt-right
 
@@ -71,7 +81,18 @@
 :javascript
   $(function() {
     $('[data-toggle="tooltip"]').tooltip()
-    addTrFunction();
+    $('.add-input-btn').on('click', function(e){
+      $add_btn = $(e.target);
+      $this_table = $add_btn.closest('.d-block').prev('.table');
+      addTrFunction($this_table);
+    })
+    $('.add-item-unit-btn').on('click',function(e){
+      $add_item_unit_btn = $(e.target);
+      $d_block = $add_item_unit_btn.closest('.d-block');
+      $item_units = $d_block.prev('.item_units');
+      addItemUnitFunction($item_units);
+      return recursiveAllFunction();
+    })
     recursiveAllFunction();
   });
   // 再起をする必要がある関数群
@@ -79,11 +100,10 @@
     $('.taobao_url_input').change(function(){
       resetTaobaoUrlLink();
     })
-    $('.form-check').on('click', function(e){
+    $('.submit_check_box').on('click', function(e){
       var $this_form_check = $(e.target);
       var $this_item_unit_tbody = $(e.target).closest('.item_unit_tbody');
-      //console.log($this_item_unit_tbody);
-      var $all_form_checks = $this_item_unit_tbody.find('.form-check');
+      var $all_form_checks = $this_item_unit_tbody.find('.submit_check_box');
       // すべてのチェックボックスのチェックを外す
       $all_form_checks.prop('checked', false);
       // 今回のチェックボックスのチェックを入れる
@@ -101,6 +121,39 @@
           break;
       }
     })
+    $('.tr_remove_btn').on('click', function(e){
+      var $this_tr_remove_btn = $(e.target);
+      var $this_tr = $this_tr_remove_btn.closest('tr');
+      var $this_tbody = $this_tr.parent();
+      var $this_table = $this_tbody.parent();
+      $this_tr.fadeOut('fast').queue(function(e) {
+        $this_tr.remove();
+        var $tbody_tr = $this_tbody.children('tr');
+        if ($tbody_tr.length == 2) {
+          addTrFunction($this_table);
+        }
+      });
+    })
+    $('.item_unit_remove_btn').on('click', function(e){
+      $item_unit_remove_btn = $(e.target)
+      $item_row =  $item_unit_remove_btn.closest('.item-row');
+      removeItemUnitFunction($item_row);
+    })
+    // 商品1,商品2..を整理
+    $(function() {
+      $item_units = $('.item_units');
+      $item_rows = $item_units.children('.item-row') ;
+      $item_rows.each(function(index, item_row){
+        $item_unit_title = $(item_row).find('.item_unit_title');
+        $item_unit_title.html(`商品 ${index + 1}`)
+      })
+    })
+    //$item_units = $('.item_units');
+    //$item_rows = $item_units.children('.item-row') ;
+    //$item_rows.each(function(index, item_row){
+    //  $item_unit_title = $(item_row).find('.item_unit_title');
+    //  $item_unit_title.html(`商品 ${index + 1}`)
+    //})
   }
   function resetTaobaoUrlLink() {
     $('.item_unit_tbody tr').each(function(index, tr_element) {
@@ -108,57 +161,183 @@
       $(tr_element).find('.fontawsome_taobao_url_link').attr('href', taobao_url);
     })
   }
-  //TaobaoUrlを入力するフォームの1行を追加する関数
-  function addTrFunction() {
-    $('.add-input-btn').on('click', function(e){
+  //TaobaoUrlを入力するフォームの1行を追加する関数 
+  function addTrFunction($this_table) {
+    $this_tbody = $this_table.children('.item_unit_tbody');
+    $this_table_last_tr = $this_table.find('tr:last');
+    $this_table_submit_check_box = $this_table_last_tr.find('.submit_check_box');
+    $last_taobao_url_input = $this_table_last_tr.find('.taobao_url_input');
+    // 最後のcheckboxのnameから追加のcheckboxのnameを作る
+    var $this_table_submit_check_box_name = $this_table_submit_check_box.attr('name');
+    var $this_table_submit_check_box_name_slice = $this_table_submit_check_box_name.slice(0, -1);
+    var $this_table_submit_check_box_name_split_array = $this_table_submit_check_box_name_slice.split('[');
+    var last_check_box_id = $this_table_submit_check_box_name_split_array[1];
+    var new_tr_id = String(Number(last_check_box_id) + 1);
+    // 最後のinputのnameから追加のinputのnameを作る
+    var last_taobao_url_input_name = $last_taobao_url_input.attr('name');
+    var last_taobao_url_input_name_split_array = last_taobao_url_input_name.split('][');
+    var new_taobao_url_input_name_split_array = last_taobao_url_input_name_split_array;
+    new_taobao_url_input_name_split_array[2] = String(Number(last_taobao_url_input_name_split_array[2]) + 1);
+    new_taobao_url_input_name_split_array[3] = '0]'
+    var new_taobao_url_input_name = new_taobao_url_input_name_split_array.join('][');
+    // 最後のinputのideから追加のinputのideを作る
+    var last_taobao_url_input_id = $last_taobao_url_input.attr('id');
+    var last_taobao_url_input_id_split_array = last_taobao_url_input_id.split('_');
+    var new_taobao_url_input_id_split_array = last_taobao_url_input_id_split_array;
+    new_taobao_url_input_id_split_array[4] = String(Number(last_taobao_url_input_id_split_array[4]) + 1);
+    new_taobao_url_input_id_split_array[5] = "0";
+    var new_taobao_url_input_id = new_taobao_url_input_id_split_array.join('_');
+    var add_new_input_html =`
+      <tr>
+      <td class="text-center align-middle">
+      <input type="checkbox" name="first_candidate_select[${new_tr_id}]" id="first_candidate_select_${new_tr_id}" value="true" class="submit_check_box">
+      </td>
+      <td class="text-center align-middle">
+      <div class="input-group">
+      <input type="text" name="${new_taobao_url_input_name}" id="${new_taobao_url_input_id}" class="form-control taobao_url_input">
+      <div class="input-group-append">
+      <span class="input-group-text" id="basic-addon2">
+      <a target="_blank" class="fontawsome_taobao_url_link" href=""><i class="fas fa-external-link-alt"></i>
+      </a></span>
+      </div>
+      </div>
+      </td>
+      <td class="text-center align-middle">
+      <select name="have_stock[${new_tr_id}]" id="have_stock_${new_tr_id}" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
+      <option value="1">在庫無し</option></select>
+      </td>
+      <td class="text-center align-middle">
+      <div class="btn btn-sm btn-outline-danger tr_remove_btn">
+      <i class="fas fa-trash-alt"></i>
+      </div>
+      </td>
+      </tr>
+    `
+    $this_tbody.append(add_new_input_html);
+    return recursiveAllFunction();
+  }
+  function addItemUnitFunction($item_units){
+    var $last_item_unit = $item_units.children('.item-row:last');
+    var $a_url_input_of_last_item_unit = $last_item_unit .find('.taobao_url_input:first');
+    var $name_of_a_url_input = $a_url_input_of_last_item_unit.attr('name');
+    var $name_of_a_url_input_array = $name_of_a_url_input.split('][');
+    var last_item_unit_id = $name_of_a_url_input_array[0].slice(-1);
+    var next_item_unit_id = String(Number(last_item_unit_id) + 1);
+    console.log(next_item_unit_id)
+    var new_item_unit_html = `
+      <div class="row mx-2 item-row">
+      <div class="col mb-5">
+      <div class="h5">
+      <div class="d-inline item_unit_title">商品 ${next_item_unit_id + 1}</div>
+      <div class="btn btn-sm btn-outline-danger item_unit_remove_btn">
+      <i class="fas fa-trash-alt"></i>
+      </div>
+      </div>
+      <table class="table table-bordered">
+      <thead class="thead-light">
+      <tr>
+      <th class="first_candidate_select">第1候補</th>
+      <th>URL</th>
+      <th>在庫</th>
+      <th>削除</th>
+      </tr>
+      </thead>
+      <tbody class="item_unit_tbody">
+      <tr>
+      <td class="text-center align-middle">
+      <input type="checkbox" name="first_candidate_select[0]" id="first_candidate_select_0" value="true" class="submit_check_box">
+      </td>
+      <td class="text-center align-middle">
+      <div class="input-group">
+      <input type="text" name="taobao_url[${next_item_unit_id}][0][0][0]" id="taobao_url_${next_item_unit_id}_0_0_0" class="form-control taobao_url_input">
+      <div class="input-group-append">
+      <span class="input-group-text" id="basic-addon2">
+      <a target="_blank" class="fontawsome_taobao_url_link" href=""><i class="fas fa-external-link-alt"></i>
+      </a></span>
+      </div>
+      </div>
+      </td>
+      <td class="text-center align-middle">
+      <select name="have_stock[0]" id="have_stock_0" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
+      <option value="1">在庫無し</option></select>
+      </td>
+      <td class="text-center align-middle">
+      <div class="btn btn-sm btn-outline-danger tr_remove_btn">
+      <i class="fas fa-trash-alt"></i>
+      </div>
+      </td>
+      </tr>
+      <tr>
+      <td class="text-center align-middle">
+      <input type="checkbox" name="first_candidate_select[1]" id="first_candidate_select_1" value="true" class="submit_check_box">
+      </td>
+      <td class="text-center align-middle">
+      <div class="input-group">
+      <input type="text" name="taobao_url[${next_item_unit_id}][0][1][0]" id="taobao_url_${next_item_unit_id}_0_1_0" class="form-control taobao_url_input">
+      <div class="input-group-append">
+      <span class="input-group-text" id="basic-addon2">
+      <a target="_blank" class="fontawsome_taobao_url_link" href=""><i class="fas fa-external-link-alt"></i>
+      </a></span>
+      </div>
+      </div>
+      </td>
+      <td class="text-center align-middle">
+      <select name="have_stock[1]" id="have_stock_1" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
+      <option value="1">在庫無し</option></select>
+      </td>
+      <td class="text-center align-middle">
+      <div class="btn btn-sm btn-outline-danger tr_remove_btn">
+      <i class="fas fa-trash-alt"></i>
+      </div>
+      </td>
+      </tr>
+      <tr>
+      <td class="text-center align-middle">
+      <input type="checkbox" name="first_candidate_select[2]" id="first_candidate_select_2" value="true" class="submit_check_box">
+      </td>
+      <td class="text-center align-middle">
+      <div class="input-group">
+      <input type="text" name="taobao_url[${next_item_unit_id}][0][2][0]" id="taobao_url_${next_item_unit_id}_0_2_0" class="form-control taobao_url_input">
+      <div class="input-group-append">
+      <span class="input-group-text" id="basic-addon2">
+      <a target="_blank" class="fontawsome_taobao_url_link" href=""><i class="fas fa-external-link-alt"></i>
+      </a></span>
+      </div>
+      </div>
+      </td>
+      <td class="text-center align-middle">
+      <select name="have_stock[2]" id="have_stock_2" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
+      <option value="1">在庫無し</option></select>
+      </td>
+      <td class="text-center align-middle">
+      <div class="btn btn-sm btn-outline-danger tr_remove_btn">
+      <i class="fas fa-trash-alt"></i>
+      </div>
+      </td>
+      </tr>
+      </tbody>
+      </table>
+      <div class="d-block" style="margin-left: 80px; margin-right: 250px;">
+      <div class="btn btn-sm btn-outline-success btn-block text-center add-input-btn add-input-btn-${next_item_unit_id}">
+      <i class="fas fa-arrow-alt-circle-up fa-lg"></i>
+      買付先URL追加
+      </div>
+      </div>
+      </div>
+      </div>
+    `
+    $item_units.append(new_item_unit_html);
+    afterPushButtonToAddTrFunction(`.add-input-btn-${next_item_unit_id}`)
+  }
+  function removeItemUnitFunction($item_row){
+    $item_row.remove();
+    return recursiveAllFunction()
+  }
+  //追加したDOM用のTr追加関数
+  function afterPushButtonToAddTrFunction(add_input_btn_i) {
+    $(add_input_btn_i).on('click', function(e){
       $add_btn = $(e.target);
-      $this_table = $add_btn.parent('.d-block').prev('.table');
-      $this_tbody = $this_table.children('.item_unit_tbody');
-      console.log($this_tbody);
-      $this_table_last_tr = $this_table.find('tr:last');
-      $this_table_submit_check_box = $this_table_last_tr.find('.submit_check_box');
-      $last_taobao_url_input = $this_table_last_tr.find('.taobao_url_input');
-      // 最後のcheckboxのnameから追加のcheckboxのnameを作る
-      var $this_table_submit_check_box_name = $this_table_submit_check_box.attr('name');
-      var $this_table_submit_check_box_name_slice = $this_table_submit_check_box_name.slice(0, -1);
-      var $this_table_submit_check_box_name_split_array = $this_table_submit_check_box_name_slice.split('[');
-      var last_check_box_id = $this_table_submit_check_box_name_split_array[1];
-      var new_tr_id = String(Number(last_check_box_id) + 1);
-      // 最後のinputのnameから追加のinputのnameを作る
-      var last_taobao_url_input_name = $last_taobao_url_input.attr('name');
-      var last_taobao_url_input_name_split_array = last_taobao_url_input_name.split('][');
-      var new_taobao_url_input_name_split_array = last_taobao_url_input_name_split_array;
-      new_taobao_url_input_name_split_array[2] = String(Number(last_taobao_url_input_name_split_array[2]) + 1);
-      new_taobao_url_input_name_split_array[3] = '0]'
-      var new_taobao_url_input_name = new_taobao_url_input_name_split_array.join('][');
-      // 最後のinputのideから追加のinputのideを作る
-      var last_taobao_url_input_id = $last_taobao_url_input.attr('id');
-      var last_taobao_url_input_id_split_array = last_taobao_url_input_id.split('_');
-      var new_taobao_url_input_id_split_array = last_taobao_url_input_id_split_array;
-      new_taobao_url_input_id_split_array[4] = String(Number(last_taobao_url_input_id_split_array[4]) + 1);
-      new_taobao_url_input_id_split_array[5] = "0";
-      var new_taobao_url_input_id = new_taobao_url_input_id_split_array.join('_');
-      var add_new_input_html =`
-        <tr>
-        <td class="pl-5 pt-4"><input type="checkbox" name="first_candidate_select[${new_tr_id}]" id="first_candidate_select_${new_tr_id}" value="true" class="form-check submit_check_box"></td>
-        <td>
-        <div class="input-group">
-        <input type="text" name="${new_taobao_url_input_name}" id="${new_taobao_url_input_id}" class="form-control taobao_url_input">
-        <div class="input-group-append">
-        <span class="input-group-text" id="basic-addon2">
-        <a target="_blank" class="fontawsome_taobao_url_link" href=""><i class="fas fa-external-link-alt"></i>
-        </a></span>
-        </div>
-        </div>
-        </td>
-        <td>
-        <select name="have_stock[${new_tr_id}]" id="have_stock_${new_tr_id}" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
-        <option value="1">在庫無し</option></select>
-        </td>
-        </tr>
-      `
-      $this_tbody.append(add_new_input_html);
-      return recursiveAllFunction();
+      $this_table = $add_btn.closest('.d-block').prev('.table');
+      addTrFunction($this_table);
     })
   }
-

--- a/app/views/item_sets/_edit.html.haml
+++ b/app/views/item_sets/_edit.html.haml
@@ -30,7 +30,7 @@
             - @item_units_and_taobao_urls_hash.keys.each_with_index do |item_unit, i|
               .row.mx-2.item-row
                 .col.mb-5
-                  .h5
+                  .h5.item_uint_and_trash
                     .d-inline.item_unit_title
                       = ""
                     -# - if i != 0
@@ -76,7 +76,7 @@
 
         %br
         .modal-footer
-          = submit_tag "保存", class: "btn btn-primary pull-right"
+          = submit_tag "保存", class: "btn btn-primary pull-right w-25"
 
 :javascript
   $(function() {
@@ -97,8 +97,11 @@
   });
   // 再起をする必要がある関数群
   function recursiveAllFunction() {
-    $('.taobao_url_input').change(function(){
+    $('.taobao_url_input').change(function(e){
       resetTaobaoUrlLink();
+      var $this_taobao_url_input = $(e.target);
+      arrangeCheckBoxByTaobaoUrlInput($this_taobao_url_input)
+      applyAlwaysOneCheckInAllItemRowFunction()
     })
     $('.submit_check_box').on('click', function(e){
       var $this_form_check = $(e.target);
@@ -111,15 +114,7 @@
     })
     $('.have_stock').change(function(e) {
       var $this_select_tag = $(e.target);
-      var n = $this_select_tag.children('option:selected').val();
-      switch (n) {
-        case '0':
-          $this_select_tag.removeClass('bg-secondary text-white');
-          break;
-        case '1':
-          $this_select_tag.addClass('bg-secondary text-white');
-          break;
-      }
+      arrangeCheckBoxByHavingStockSelectTag($this_select_tag);
     })
     $('.tr_remove_btn').on('click', function(e){
       var $this_tr_remove_btn = $(e.target);
@@ -147,14 +142,27 @@
         $item_unit_title = $(item_row).find('.item_unit_title');
         $item_unit_title.html(`商品 ${index + 1}`)
       })
+      var item_rows_length = $item_rows.length;
+      if (item_rows_length > 1) {
+        $('.item_uint_and_trash').removeClass('d-none');
+      } else {
+        $('.item_uint_and_trash').addClass('d-none');
+      }
     })
-    //$item_units = $('.item_units');
-    //$item_rows = $item_units.children('.item-row') ;
-    //$item_rows.each(function(index, item_row){
-    //  $item_unit_title = $(item_row).find('.item_unit_title');
-    //  $item_unit_title.html(`商品 ${index + 1}`)
-    //})
+    //在庫有り・無しの内容を取ってっ来て、第一候補のチェックボックスをdisabledにしたり、チェック外したりする
+    $('.have_stock').each(function(index, this_select_tag) {
+      var $this_select_tag = $(this_select_tag);
+      arrangeCheckBoxByHavingStockSelectTag($this_select_tag)
+    })
+    // taobao_url_inputが空なら、第一候補のチェックボックスをdisabledにしたり、チェック外したりする
+    $('.taobao_url_input').each(function(index, this_taobao_url_input) {
+      var $this_taobao_url_input = $(this_taobao_url_input);
+      arrangeCheckBoxByTaobaoUrlInput($this_taobao_url_input)
+    })
+    applyAlwaysOneCheckInAllItemRowFunction()
   }
+  
+  
   function resetTaobaoUrlLink() {
     $('.item_unit_tbody tr').each(function(index, tr_element) {
       var taobao_url = $(tr_element).find('.taobao_url_input').val();
@@ -223,11 +231,10 @@
     var $name_of_a_url_input_array = $name_of_a_url_input.split('][');
     var last_item_unit_id = $name_of_a_url_input_array[0].slice(-1);
     var next_item_unit_id = String(Number(last_item_unit_id) + 1);
-    console.log(next_item_unit_id)
     var new_item_unit_html = `
       <div class="row mx-2 item-row">
       <div class="col mb-5">
-      <div class="h5">
+      <div class="h5 item_uint_and_trash">
       <div class="d-inline item_unit_title">商品 ${next_item_unit_id + 1}</div>
       <div class="btn btn-sm btn-outline-danger item_unit_remove_btn">
       <i class="fas fa-trash-alt"></i>
@@ -339,5 +346,80 @@
       $add_btn = $(e.target);
       $this_table = $add_btn.closest('.d-block').prev('.table');
       addTrFunction($this_table);
+    })
+  }
+  function arrangeCheckBoxByHavingStockSelectTag($this_select_tag) {
+    var n = $this_select_tag.children('option:selected').val();
+    var $this_tr = $this_select_tag.closest('tr');
+    var $this_taobao_url_input = $this_tr.find('.taobao_url_input');
+    var $this_taobao_url_input = $this_taobao_url_input.val();
+    var $this_submit_check_box = $this_tr.find('.submit_check_box');
+    if ($this_taobao_url_input == ""){
+      switch (n) {
+        case '0':
+          $this_select_tag.removeClass('bg-secondary text-white');
+          break;
+        case '1':
+          $this_select_tag.addClass('bg-secondary text-white');
+          break;
+      }
+    } else {
+      switch (n) {
+        case '0':
+          $this_select_tag.removeClass('bg-secondary text-white');
+          $this_submit_check_box.prop('disabled', false);
+          break;
+        case '1':
+          $this_select_tag.addClass('bg-secondary text-white');
+          $this_submit_check_box.prop('checked', false);
+          $this_submit_check_box.prop('disabled', true);
+          break; 
+      }
+    }
+  }
+  function arrangeCheckBoxByTaobaoUrlInput($this_taobao_url_input){
+    var this_taobao_url_input_val = $this_taobao_url_input.val();
+    var $this_tr = $this_taobao_url_input.closest('tr');
+    var $this_select_tag = $this_tr.find('.have_stock');
+    var n = $this_select_tag.children('option:selected').val();
+    var $this_submit_check_box = $this_tr.find('.submit_check_box');
+    if (n == '0'){
+      if (this_taobao_url_input_val == ""){
+        $this_submit_check_box.prop('checked', false);
+        $this_submit_check_box.prop('disabled', true);
+      } else {
+        $this_submit_check_box.prop('disabled', false);
+      }
+    }
+  }
+  function applyAlwaysOneCheckInItemRowFunction($item_row){
+    var $all_submit_check_box = $item_row.find('.submit_check_box');
+    var all_check_situation_array = [];
+    $all_submit_check_box.each(function(index, submit_check_box){
+      var $submit_check_box = $(submit_check_box);
+      var check_situation = $submit_check_box.attr('checked');
+      all_check_situation_array.push(check_situation)
+    })
+    if ($.inArray('checked', all_check_situation_array) == -1) {
+      var $item_unit_tbody = $item_row.find('.item_unit_tbody')
+      var $this_all_tr = $item_unit_tbody.find('tr');
+      $this_all_tr.each(function(index, tr){
+        var $this_tr = $(tr);
+        var $this_taobao_url_input = $this_tr.find('.taobao_url_input');
+        var $this_taobao_url_input_val = $this_taobao_url_input.val();
+        var $this_select_tag = $this_tr.find('.have_stock');
+        var n = $this_select_tag.children('option:selected').val();
+        var $this_submit_check_box = $this_tr.find('.submit_check_box');
+        if ($this_taobao_url_input_val != "" && n == '0'){
+          $this_submit_check_box.prop('checked', true);
+          return false;
+        }
+      })
+    }
+  }
+  function applyAlwaysOneCheckInAllItemRowFunction(){
+    $('.item-row').each(function(index, item_row){
+      $item_row = $(item_row);
+      applyAlwaysOneCheckInItemRowFunction($item_row);
     })
   }

--- a/app/views/item_sets/_edit.html.haml
+++ b/app/views/item_sets/_edit.html.haml
@@ -1,0 +1,67 @@
+.modal-dialog.modal-lg#item_sets_modal
+  / モーダルのコンテンツ部分
+  .modal-content
+    / モーダルのヘッダー
+    .container
+      .modal-header
+        / モーダルのタイトル
+        .h4#exampleModalLabel.modal-title 買付先情報（マスター）
+        / 閉じるアイコン
+        %button.close{"aria-label" => "Close", "data-dismiss" => "modal", :type => "button"}
+          %span{"aria-hidden" => "true"} ×
+      = form_tag item_set_path(@item_set), method: :put do 
+        / モーダルの本文
+        .modal-body
+          .d-table
+            .d-table-row
+              .d-table-cell.border.border-secondary.bg-info.text-white.px-2.pt-1
+                .h5
+                  カテゴリー - 商品ID
+              .d-table-cell.border.border-secondary.px-2.pt-1
+                .h5
+                  = I18n.t("activerecord.attributes.item_set.item_no_category.#{@item_set.item_no_category}", locale: :ja)
+                  = "-"
+                  = @item_set.item_no
+          .row
+            .col.my-2
+              = link_to @item_set.shop_url, @item_set.shop_url, :target=>["_blank"]
+          %br
+          .h4 買付先URL
+          .row
+            .col
+              %table.table.table-bordered
+                %thead.thead-light
+                  %tr
+                    %th.first_canditate_select 第一候補
+                    %th URL
+                    %th 在庫
+                %tbody#item_sets_table
+                  - @item_units_and_taobao_urls_hash.keys.each_with_index do |item_unit, i|
+                    - @item_units_and_taobao_urls_hash[item_unit].each_with_index do |taobao_url, j|
+                      %tr
+                        %td.pl-5.pt-4= check_box_tag "to_do", true, false, class: "form-check submit_check_box"
+                        %td
+                          .input-group
+                            = text_field_tag "taobao_url[#{i}][#{item_unit.id.to_i}][#{j}][#{taobao_url.id.to_i}]", taobao_url.url, class: "form-control taobao_url_input"
+                            .input-group-append
+                              %span#basic-addon2.input-group-text
+                                = link_to taobao_url.url, :target=>["_blank"], class: "fontawsome_taobao_url_link" do
+                                  %i.fas.fa-external-link-alt
+                        %td
+        %br
+        .modal-footer
+          = submit_tag "保存", class: "btn btn-primary pull-right"
+
+
+:javascript
+  $(function() {
+    $('.taobao_url_input').change(function(){
+      resetTaobaoUrlLink();
+    })
+  });
+  function resetTaobaoUrlLink() {
+    $('#item_sets_table tr').each(function(index, tr_element) {
+      var taobao_url = $(tr_element).find('.taobao_url_input').val();
+      $(tr_element).find('.fontawsome_taobao_url_link').attr('href', taobao_url);
+    })
+  }

--- a/app/views/item_sets/_edit.html.haml
+++ b/app/views/item_sets/_edit.html.haml
@@ -47,7 +47,7 @@
                         %tr
                           - check_box_true_or_false = item_unit.first_candidate_id == taobao_url.id && item_unit.first_candidate_id.present? ? true : false
                           %td.text-center.align-middle
-                            = check_box_tag "first_candidate_select[#{k}]", true, check_box_true_or_false, class: "submit_check_box"
+                            = check_box_tag "first_candidate_select[#{i}][#{k}]", true, check_box_true_or_false, class: "submit_check_box"
                           %td.text-center.align-middle
                             .input-group
                               = text_field_tag "taobao_url[#{i}][#{item_unit.id.to_i}][#{k}][#{taobao_url.id.to_i}]", taobao_url.url, class: "form-control taobao_url_input"
@@ -59,7 +59,7 @@
                           %td.text-center.align-middle
                             - have_stock_options = TaobaoUrl.is_have_stocks.map {|key, value| [ I18n.t("activerecord.attributes.taobao_url.is_have_stock.#{key}", locale: :ja), value]}
                             - have_stock_class = taobao_url.is_have_stock == "have_stock" ? "have_stock form-control" : "have_stock form-control bg-secondary text-white"
-                            = select_tag "have_stock[#{k}]", options_for_select(have_stock_options, selected: taobao_url.is_have_stock_before_type_cast), class: have_stock_class
+                            = select_tag "have_stock[#{i}][#{k}]", options_for_select(have_stock_options, selected: taobao_url.is_have_stock_before_type_cast), class: have_stock_class
                           %td.text-center.align-middle
                             .btn.btn-sm.btn-outline-danger.tr_remove_btn
                               %i.fas.fa-trash-alt
@@ -178,8 +178,9 @@
     var $this_table_submit_check_box_name = $this_table_submit_check_box.attr('name');
     var $this_table_submit_check_box_name_slice = $this_table_submit_check_box_name.slice(0, -1);
     var $this_table_submit_check_box_name_split_array = $this_table_submit_check_box_name_slice.split('[');
-    var last_check_box_id = $this_table_submit_check_box_name_split_array[1];
+    var last_check_box_id = $this_table_submit_check_box_name_split_array[2];
     var new_tr_id = String(Number(last_check_box_id) + 1);
+    var this_item_unit_id = $this_table_submit_check_box_name_split_array[1].slice(0, -1)
     // 最後のinputのnameから追加のinputのnameを作る
     var last_taobao_url_input_name = $last_taobao_url_input.attr('name');
     var last_taobao_url_input_name_split_array = last_taobao_url_input_name.split('][');
@@ -197,7 +198,7 @@
     var add_new_input_html =`
       <tr>
       <td class="text-center align-middle">
-      <input type="checkbox" name="first_candidate_select[${new_tr_id}]" id="first_candidate_select_${new_tr_id}" value="true" class="submit_check_box">
+      <input type="checkbox" name="first_candidate_select[${this_item_unit_id}][${new_tr_id}]" id="first_candidate_select_${this_item_unit_id}_${new_tr_id}" value="true" class="submit_check_box">
       </td>
       <td class="text-center align-middle">
       <div class="input-group">
@@ -210,7 +211,7 @@
       </div>
       </td>
       <td class="text-center align-middle">
-      <select name="have_stock[${new_tr_id}]" id="have_stock_${new_tr_id}" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
+      <select name="have_stock[${this_item_unit_id}][${new_tr_id}]" id="have_stock_${this_item_unit_id}_${new_tr_id}" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
       <option value="1">在庫無し</option></select>
       </td>
       <td class="text-center align-middle">
@@ -251,7 +252,7 @@
       <tbody class="item_unit_tbody">
       <tr>
       <td class="text-center align-middle">
-      <input type="checkbox" name="first_candidate_select[0]" id="first_candidate_select_0" value="true" class="submit_check_box">
+      <input type="checkbox" name="first_candidate_select[${next_item_unit_id}][0]" id="first_candidate_select_[${next_item_unit_id}]_0" value="true" class="submit_check_box">
       </td>
       <td class="text-center align-middle">
       <div class="input-group">
@@ -264,7 +265,7 @@
       </div>
       </td>
       <td class="text-center align-middle">
-      <select name="have_stock[0]" id="have_stock_0" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
+      <select name="have_stock[${next_item_unit_id}][0]" id="have_stock_[${next_item_unit_id}]_0" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
       <option value="1">在庫無し</option></select>
       </td>
       <td class="text-center align-middle">
@@ -275,7 +276,7 @@
       </tr>
       <tr>
       <td class="text-center align-middle">
-      <input type="checkbox" name="first_candidate_select[1]" id="first_candidate_select_1" value="true" class="submit_check_box">
+      <input type="checkbox" name="first_candidate_select[${next_item_unit_id}][1]" id="first_candidate_select_${next_item_unit_id}_1" value="true" class="submit_check_box">
       </td>
       <td class="text-center align-middle">
       <div class="input-group">
@@ -288,7 +289,7 @@
       </div>
       </td>
       <td class="text-center align-middle">
-      <select name="have_stock[1]" id="have_stock_1" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
+      <select name="have_stock[${next_item_unit_id}][1]" id="have_stock_[${next_item_unit_id}]_1" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
       <option value="1">在庫無し</option></select>
       </td>
       <td class="text-center align-middle">
@@ -299,7 +300,7 @@
       </tr>
       <tr>
       <td class="text-center align-middle">
-      <input type="checkbox" name="first_candidate_select[2]" id="first_candidate_select_2" value="true" class="submit_check_box">
+      <input type="checkbox" name="first_candidate_select[${next_item_unit_id}][2]" id="first_candidate_select_${next_item_unit_id}_2" value="true" class="submit_check_box">
       </td>
       <td class="text-center align-middle">
       <div class="input-group">
@@ -312,7 +313,7 @@
       </div>
       </td>
       <td class="text-center align-middle">
-      <select name="have_stock[2]" id="have_stock_2" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
+      <select name="have_stock[${next_item_unit_id}][2]" id="have_stock_[${next_item_unit_id}]_2" class="have_stock form-control"><option selected="selected" value="0">在庫有り</option>
       <option value="1">在庫無し</option></select>
       </td>
       <td class="text-center align-middle">
@@ -375,6 +376,7 @@
           break; 
       }
     }
+    applyAlwaysOneCheckInAllItemRowFunction()
   }
   function arrangeCheckBoxByTaobaoUrlInput($this_taobao_url_input){
     var this_taobao_url_input_val = $this_taobao_url_input.val();

--- a/app/views/item_sets/_edit.html.haml
+++ b/app/views/item_sets/_edit.html.haml
@@ -22,8 +22,7 @@
                   = link_to @item_set.shop_url, :target=>["_blank"] do
                     = I18n.t("activerecord.attributes.item_set.item_no_category.#{@item_set.item_no_category}", locale: :ja)
                     = "-"
-                    = @item_set.item_no
-              
+                    = @item_set.item_no 
           %br
           .h4 買付先URL
           .item_units
@@ -38,7 +37,9 @@
                   %table.table.table-bordered
                     %thead.thead-light
                       %tr
-                        %th.first_candidate_select 第1候補
+                        %th.first_candidate_select.text-center
+                          優先
+                          %i.fas.fa-question-circle{title: '優先的に購入してほしい店舗に、1つだけチェックをいれてください。', data: { toggle: "tooltip", placement: "top", delay: { "show": 200, "hide": 100 }}}
                         %th URL
                         %th 在庫
                         %th 削除
@@ -243,7 +244,10 @@
       <table class="table table-bordered">
       <thead class="thead-light">
       <tr>
-      <th class="first_candidate_select">第1候補</th>
+      <th class="first_candidate_select text-center">
+      優先
+      <i class="fas fa-question-circle" data-delay-hide="100" data-delay-show="200" data-placement="top" data-toggle="tooltip" title="" data-original-title="優先的に購入してほしい店舗に、1つだけチェックをいれてください。"></i>
+      </th>
       <th>URL</th>
       <th>在庫</th>
       <th>削除</th>
@@ -335,6 +339,7 @@
     `
     $item_units.append(new_item_unit_html);
     afterPushButtonToAddTrFunction(`.add-input-btn-${next_item_unit_id}`)
+    $('[data-toggle="tooltip"]').tooltip()
   }
   function removeItemUnitFunction($item_row){
     $item_row.remove();

--- a/app/views/item_sets/_edit.html.haml
+++ b/app/views/item_sets/_edit.html.haml
@@ -19,44 +19,50 @@
                   カテゴリー - 商品ID
               .d-table-cell.border.border-secondary.px-2.pt-1
                 .h5
-                  = I18n.t("activerecord.attributes.item_set.item_no_category.#{@item_set.item_no_category}", locale: :ja)
-                  = "-"
-                  = @item_set.item_no
-          .row
-            .col.my-2
-              = link_to @item_set.shop_url, @item_set.shop_url, :target=>["_blank"]
+                  = link_to @item_set.shop_url, :target=>["_blank"] do
+                    = I18n.t("activerecord.attributes.item_set.item_no_category.#{@item_set.item_no_category}", locale: :ja)
+                    = "-"
+                    = @item_set.item_no
+              
           %br
           .h4 買付先URL
           - @item_units_and_taobao_urls_hash.keys.each_with_index do |item_unit, i|
-            .row
-              .col
-                %table.table.table-bordered
-                  %thead.thead-light
-                    %tr
-                      %th.first_candidate_select 第一候補
-                      %th URL
-                      %th 在庫
-                  %tbody.item_unit_tbody
-                    - @item_units_and_taobao_urls_hash[item_unit].each_with_index do |taobao_url, k|
+            .row.mx-2
+              .col.mb-5
+                .h5
+                  = "商品 #{i + 1}"
+                .d-block.ml-2
+                  %table.table.table-bordered
+                    %thead.thead-light
                       %tr
-                        - check_box_true_or_false = item_unit.first_candidate_id == taobao_url.id && item_unit.first_candidate_id.present? ? true : false
-                        %td.pl-5.pt-4= check_box_tag "first_candidate_select[#{k}]", true, check_box_true_or_false, class: "form-check submit_check_box"
-                        %td
-                          .input-group
-                            = text_field_tag "taobao_url[#{i}][#{item_unit.id.to_i}][#{k}][#{taobao_url.id.to_i}]", taobao_url.url, class: "form-control taobao_url_input"
-                            .input-group-append
-                              %span#basic-addon2.input-group-text
-                                - taobao_url_url = taobao_url.url.nil? ? '' : taobao_url.url
-                                = link_to taobao_url_url, :target=>["_blank"], class: "fontawsome_taobao_url_link" do
-                                  %i.fas.fa-external-link-alt
-                        %td
-                          - have_stock_options = TaobaoUrl.is_have_stocks.map {|key, value| [ I18n.t("activerecord.attributes.taobao_url.is_have_stock.#{key}", locale: :ja), value]}
-                          - have_stock_class = taobao_url.is_have_stock == "have_stock" ? "have_stock form-control" : "have_stock form-control bg-secondary text-white"
-                          = select_tag "have_stock[#{k}]", options_for_select(have_stock_options, selected: taobao_url.is_have_stock_before_type_cast), class: have_stock_class
-                -# .d-inline
-                .btn.btn-sm.btn-success.text-center.add-input-btn
-                  %i.far.fa-arrow-alt-circle-up
-                  買付先URL追加
+                        %th.first_candidate_select 第1候補
+                        %th URL
+                        %th 在庫
+                    %tbody.item_unit_tbody
+                      - @item_units_and_taobao_urls_hash[item_unit].each_with_index do |taobao_url, k|
+                        %tr
+                          - check_box_true_or_false = item_unit.first_candidate_id == taobao_url.id && item_unit.first_candidate_id.present? ? true : false
+                          %td.pl-5.pt-4= check_box_tag "first_candidate_select[#{k}]", true, check_box_true_or_false, class: "form-check submit_check_box"
+                          %td
+                            .input-group
+                              = text_field_tag "taobao_url[#{i}][#{item_unit.id.to_i}][#{k}][#{taobao_url.id.to_i}]", taobao_url.url, class: "form-control taobao_url_input"
+                              .input-group-append
+                                %span#basic-addon2.input-group-text
+                                  - taobao_url_url = taobao_url.url.nil? ? '' : taobao_url.url
+                                  = link_to taobao_url_url, :target=>["_blank"], class: "fontawsome_taobao_url_link" do
+                                    %i.fas.fa-external-link-alt
+                          %td
+                            - have_stock_options = TaobaoUrl.is_have_stocks.map {|key, value| [ I18n.t("activerecord.attributes.taobao_url.is_have_stock.#{key}", locale: :ja), value]}
+                            - have_stock_class = taobao_url.is_have_stock == "have_stock" ? "have_stock form-control" : "have_stock form-control bg-secondary text-white"
+                            = select_tag "have_stock[#{k}]", options_for_select(have_stock_options, selected: taobao_url.is_have_stock_before_type_cast), class: have_stock_class
+                  .d-block{style: 'margin-left: 80px; margin-right: 197px;'}
+                    .btn.btn-sm.btn-outline-success.btn-block.text-center.add-input-btn
+                      %i.fas.fa-arrow-alt-circle-up.fa-lg
+                      買付先URL追加
+          .d-block
+            .btn.btn-sm.btn-outline-warning.text-center.add-input-btn{title: 'セット商品の場合などで登録したい場合は、商品を追加してください', data: { toggle: "tooltip", placement: "top", delay: { "show": 200, "hide": 100 }}}
+              商品追加
+              %i.fas.fa-long-arrow-alt-right
 
         %br
         .modal-footer
@@ -64,6 +70,7 @@
 
 :javascript
   $(function() {
+    $('[data-toggle="tooltip"]').tooltip()
     addTrFunction();
     recursiveAllFunction();
   });
@@ -105,7 +112,7 @@
   function addTrFunction() {
     $('.add-input-btn').on('click', function(e){
       $add_btn = $(e.target);
-      $this_table = $add_btn.prev('.table');
+      $this_table = $add_btn.parent('.d-block').prev('.table');
       $this_tbody = $this_table.children('.item_unit_tbody');
       console.log($this_tbody);
       $this_table_last_tr = $this_table.find('tr:last');

--- a/app/views/item_sets/_edit.html.haml
+++ b/app/views/item_sets/_edit.html.haml
@@ -33,7 +33,6 @@
                   .h5.item_uint_and_trash
                     .d-inline.item_unit_title
                       = ""
-                    -# - if i != 0
                     .btn.btn-sm.btn-outline-danger.item_unit_remove_btn
                       %i.fas.fa-trash-alt
                   %table.table.table-bordered
@@ -397,10 +396,10 @@
     var all_check_situation_array = [];
     $all_submit_check_box.each(function(index, submit_check_box){
       var $submit_check_box = $(submit_check_box);
-      var check_situation = $submit_check_box.attr('checked');
+      var check_situation = $submit_check_box.prop('checked');
       all_check_situation_array.push(check_situation)
     })
-    if ($.inArray('checked', all_check_situation_array) == -1) {
+    if ($.inArray(true, all_check_situation_array) == -1) {
       var $item_unit_tbody = $item_row.find('.item_unit_tbody')
       var $this_all_tr = $item_unit_tbody.find('tr');
       $this_all_tr.each(function(index, tr){

--- a/app/views/item_sets/edit.js.erb
+++ b/app/views/item_sets/edit.js.erb
@@ -1,0 +1,2 @@
+$("#modal").html("<%= escape_javascript(render 'edit') %>");
+$("#modal").modal("show");

--- a/app/views/item_sets/index.html.haml
+++ b/app/views/item_sets/index.html.haml
@@ -1,0 +1,33 @@
+.d-block.m-4.pt-4
+  .row
+    .col-5.bg-light.border.border-info.rounded.shadow-sm
+      = form_tag search_item_sets_path, method: :get do
+        .row.my-3
+          .col-lg-4.d-flex.align-items-center
+            %label プラットフォーム
+          .col-lg-8
+            - plat_forms = [['指定なし', 0], ['BUYMA', 1], ['Amazon', 2]]
+            = select_tag :item_no_category, options_for_select(plat_forms)
+        .row.my-3
+          .col-lg-4.d-flex.align-items-center
+            %label No.
+          .col-lg-8
+            = text_field_tag :item_no, nil, class: "form-control d-inline w-100"
+        .row.my-4
+          .col-lg-8.offset-lg-4
+            = submit_tag :検索, class: "form-control btn btn-primary"
+  .row.mt-3
+    .col.bg-light.pt-3
+      .col-4
+        %table.table.table-bordered
+          %thead.thead-light
+            %tr
+              %th.align-middle カテゴリー
+              %th.align-middle 編集
+
+
+
+
+:javascript
+  $("#item_no_category").select2({width:'100%'});
+  $("#plat_form_ids").select2({width:'150'});

--- a/app/views/item_sets/search.html.haml
+++ b/app/views/item_sets/search.html.haml
@@ -1,0 +1,29 @@
+.d-block.m-4.pt-4
+  .row
+    .col-5.bg-light.border.border-info.rounded.shadow-sm
+      = form_tag search_item_sets_path, method: :get do
+        .row.my-3
+          .col-lg-4.d-flex.align-items-center
+            %label プラットフォーム
+          .col-lg-8
+            - plat_forms = [['指定なし', 0], ['BUYMA', 1], ['Amazon', 2]]
+            = select_tag :item_no_category, options_for_select(plat_forms)
+        .row.my-3
+          .col-lg-4.d-flex.align-items-center
+            %label No.
+          .col-lg-8
+            = text_field_tag :item_no, nil, class: "form-control d-inline w-100"
+        .row.my-4
+          .col-lg-8.offset-lg-4
+            = submit_tag :検索, class: "form-control btn btn-primary"
+  .row.mt-3
+    .col.bg-light.pt-3
+      .d-inline-bocks カテゴリー - No
+      .d-inline-bocks= @item_set.item_no_category.to_s + " - " + @item_set.item_no.to_s
+
+
+
+
+:javascript
+  $("#item_no_category").select2({width:'100%'});
+  $("#plat_form_ids").select2({width:'150'});

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,7 @@
       - key = "info" if key == "notice"
       - key = "danger"  if key == "alert"
       .fixed-top
-        %div{class: "alert alert-#{key} alert-dismissible text-center", role: 'alert'}
+        %div{class: "alert alert-#{key} alert-dismissible text-center fade show", role: 'alert'}
           = value
           %button.close{aria: {label: 'Close'}, data: {dismiss: 'alert'}, type: 'button'}
             %span{aria: {hidden: 'true'}} ×
@@ -32,3 +32,5 @@
     -# 2重にモーダル開くとき用のモーダル
     #modal-overlay.modal.fade{role: 'dialog', aria: {hidden: 'true'}, data: {backdrop: 'overlay'}}
 
+:javascript
+  $('.alert-success').delay(1500).fadeOut("slow");

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,14 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
+    - flash.each do |key, value|
+      - key = "info" if key == "notice"
+      - key = "danger"  if key == "alert"
+      .fixed-top
+        %div{class: "alert alert-#{key} alert-dismissible text-center", role: 'alert'}
+          = value
+          %button.close{aria: {label: 'Close'}, data: {dismiss: 'alert'}, type: 'button'}
+            %span{aria: {hidden: 'true'}} ×
     #wrapper.d-flex{style: "overflow-x: scroll;"}
       / Sidebar
       = render 'shared/sidebar'
@@ -23,3 +31,4 @@
     #modal-static.modal.fade{role: 'dialog', aria: {hidden: 'true'}, data: {backdrop: 'static'}}
     -# 2重にモーダル開くとき用のモーダル
     #modal-overlay.modal.fade{role: 'dialog', aria: {hidden: 'true'}, data: {backdrop: 'overlay'}}
+

--- a/app/views/orders/_edit.html.haml
+++ b/app/views/orders/_edit.html.haml
@@ -14,7 +14,12 @@
         .row
           .col
             %h4 注文No: #{@order.trade_no}
-            %h4 商品名: #{@order.item_name}
+            %h4 商品名: #{@order.item_set.item_set_name}
+            %h4
+              = link_to @order.item_set.shop_url, :target=>["_blank"] do
+                = I18n.t("activerecord.attributes.item_set.item_no_category.#{@order.item_set.item_no_category}", locale: :ja)
+                = "-"
+                = @order.item_set.item_no
             %br/
         = form_for(@order, url: order_path(id: @order.id)) do |f|
           .row.justify-content-center

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -92,7 +92,6 @@
           %td.align-middle
             = ""
           %td.align-middle.text-center
-            -# = link_to edit_order_path(id: order.id), class: "btn btn-blue btn-ml", remote: true do
             = link_to edit_order_path(order.id), class: "btn btn-blue btn-ml edit-btn", remote: true do
               %i.far.fa-edit
 

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -4,12 +4,18 @@
   .d-inline-block
     = link_to "注文手入力", new_order_manual_input_path, class: "btn btn-light border-secondary", remote: true
 %br
-.table-responsive.mt-4
+.table-responsive.mt-4{style: "width: 1500px"}
   %table.table.table-hover.table-bordered
     %thead.thead-light
       %tr
         %th.align-middle 注文No
-        %th.align-middle 商品写真
+        %th.align-middle 注文商品画像
+        %th.align-middle
+          カテゴリー - 商品ID
+          %br
+          販売サイト
+          %br
+          買付先情報（マスター）
         %th.align-middle 色・サイズ・数量
         %th.align-middle お届け先
         %th.align-middle 予定費用
@@ -17,7 +23,7 @@
         %th.align-middle 発注状況
         %th.align-middle 直接編集
     %tbody
-      -@orders.each do |order|
+      -@orders.includes(:item_set).each do |order|
         %tr
           %td.align-middle
             = order.trade_no
@@ -36,6 +42,21 @@
                     = link_to "編集", edit_picture_path(picture.id, order_id: order.id, button: i + 1), remote: true, class: "btn btn-primary edit-btn mt-1"
               .ks-2.d-block.bg-light.text-center.picture-addition-block{id: "order-id-#{order.id}_picture-#{order.pictures.length + 1}"}
                 = link_to "追加", new_picture_path(order_id: order.id, button: order.pictures.length + 1), remote: true, class: "btn btn-sm btn-success add-btn m-1 ks-3"
+          %td
+            = I18n.t("activerecord.attributes.item_set.item_no_category.#{order.item_set.item_no_category}", locale: :ja)
+            = "-"
+            = order.item_set.item_no
+            %hr/
+            = link_to order.item_set.shop_url, order.item_set.shop_url, :target=>["_blank"]
+            %hr/
+            - if order.item_set.item_units.any?
+              = link_to edit_item_set_path(order.item_set), remote: true, class: "btn btn-light" do
+                買付先情報（マスター）登録済
+                %i.fas.fa-external-link-alt.ml-2
+            - else
+              = link_to edit_item_set_path(order.item_set), remote: true, class: "btn btn-danger" do
+                買付先情報（マスター）未登録
+                %i.fas.fa-external-link-square-alt.ml-2
           %td{style: "max-width: 180px;"}
             .d-inline-block
               色・サイズ：

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -54,7 +54,7 @@
                 買付先情報（マスター）登録済
                 %i.fas.fa-external-link-alt.ml-2
             - else
-              = link_to edit_item_set_path(order.item_set), remote: true, class: "btn btn-danger" do
+              = link_to edit_item_set_path(order.item_set), remote: true, class: "btn btn-outline-danger" do
                 買付先情報（マスター）未登録
                 %i.fas.fa-external-link-square-alt.ml-2
           %td{style: "max-width: 180px;"}

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -5,7 +5,7 @@
     %ul.navbar-nav.ml-auto.mt-2.mt-lg-0
       %li.nav-item.dropdown
         %a#navbarDropdown.nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :href => "#", :role => "button"}
-          = current_user.name
+          = current_user&.name
         %ul.dropdown-menu.dropdown-menu-right{"aria-labelledby" => "navbarDropdown"}
           %li.dropdown-item
             = link_to "別アカウントにログイン", destroy_user_session_path, method: :delete, class: "dropdown-item"

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -8,7 +8,7 @@
         %i.fas.far.fa-list-alt.fa-lg.active.list-fontawsome.mt-1
         .active.list-item 注文一覧
     %li
-      = link_to root_path, class: "list-group-item list-group-item-action bg-light" do
+      = link_to item_sets_path, class: "list-group-item list-group-item-action bg-light" do
         %i.fa.fa-store-alt.fa-lg.active.list-fontawsome.mt-1
         .active.list-item 買付先一覧
   .d-block.mt-2

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,9 @@ module ChinaTradeSystem
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.i18n.default_locale = :ja  
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,3 +12,7 @@ ja:
           unspecified: "指定無し"
           buyma: "BUYMA"
           amazon: "AMAZON"
+      taobao_url:
+        is_have_stock:
+          have_stock: "在庫有り"
+          not_have_stock: "在庫無し"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,14 @@
+---
+ja:
+  hello: "こんにちは"
+  activerecords: "アクティ具レコード"
+  activerecord:
+    errors:
+    models:
+    attributes:
+      order:
+      item_set:
+        item_no_category:
+          unspecified: "指定無し"
+          buyma: "BUYMA"
+          amazon: "AMAZON"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,10 @@ Rails.application.routes.draw do
   end
   resources :order_csv_imports, only: %i[index]
   resources :order_manual_inputs, only: %i[new create]
+  resources :item_sets do
+    collection do
+      get :search
+    end
+  end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20200315135859_rename_item_no_to_item_set.rb
+++ b/db/migrate/20200315135859_rename_item_no_to_item_set.rb
@@ -1,0 +1,5 @@
+class RenameItemNoToItemSet < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :item_nos, :item_sets
+  end
+end

--- a/db/migrate/20200315140353_rename_columns_to_items_set.rb
+++ b/db/migrate/20200315140353_rename_columns_to_items_set.rb
@@ -1,0 +1,5 @@
+class RenameColumnsToItemsSet < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :item_sets, :item_name, :item_set_name
+  end
+end

--- a/db/migrate/20200315141527_remove_item_no_from_item_set.rb
+++ b/db/migrate/20200315141527_remove_item_no_from_item_set.rb
@@ -1,0 +1,9 @@
+class RemoveItemNoFromItemSet < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :item_sets, :item_no
+  end
+
+  def down
+    add_column :item_sets, :item_no, :integer
+  end
+end

--- a/db/migrate/20200315163501_add_column_to_item_set.rb
+++ b/db/migrate/20200315163501_add_column_to_item_set.rb
@@ -1,0 +1,9 @@
+class AddColumnToItemSet < ActiveRecord::Migration[5.2]
+  def up
+    add_column :item_sets, :item_no, :integer
+  end
+
+  def down
+    remove_column :item_sets, :item_no, :integer
+  end
+end

--- a/db/migrate/20200315164210_add_reference_to_order_for_item_set.rb
+++ b/db/migrate/20200315164210_add_reference_to_order_for_item_set.rb
@@ -1,0 +1,5 @@
+class AddReferenceToOrderForItemSet < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :orders, :item_set, foreign_key: true
+  end
+end

--- a/db/migrate/20200316001945_add_item_no_category_to_orders.rb
+++ b/db/migrate/20200316001945_add_item_no_category_to_orders.rb
@@ -1,0 +1,5 @@
+class AddItemNoCategoryToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :item_no_category, :integer
+  end
+end

--- a/db/migrate/20200316002251_add_item_no_category_to_item_sets.rb
+++ b/db/migrate/20200316002251_add_item_no_category_to_item_sets.rb
@@ -1,0 +1,5 @@
+class AddItemNoCategoryToItemSets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :item_sets, :item_no_category, :integer, comment: '指定なし,Buyma,Amazon..'
+  end
+end

--- a/db/migrate/20200317143556_remove_foreign_key_from_item_unit.rb
+++ b/db/migrate/20200317143556_remove_foreign_key_from_item_unit.rb
@@ -1,0 +1,9 @@
+class RemoveForeignKeyFromItemUnit < ActiveRecord::Migration[5.2]
+  def up
+    remove_reference  :item_varieties,  :item_no
+  end
+
+  def down
+    remove_reference  :item_varieties,  :item_no
+  end
+end

--- a/db/migrate/20200317145514_rename_item_variety.rb
+++ b/db/migrate/20200317145514_rename_item_variety.rb
@@ -1,0 +1,5 @@
+class RenameItemVariety < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :item_varieties, :item_units
+  end
+end

--- a/db/migrate/20200317150055_rename_column_to_item_unit.rb
+++ b/db/migrate/20200317150055_rename_column_to_item_unit.rb
@@ -1,0 +1,5 @@
+class RenameColumnToItemUnit < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :item_units, :item_taobao_name, :item_unit_name
+  end
+end

--- a/db/migrate/20200317150858_add_reference_to_item_unit.rb
+++ b/db/migrate/20200317150858_add_reference_to_item_unit.rb
@@ -1,0 +1,5 @@
+class AddReferenceToItemUnit < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :item_units, :item_set, foreign_key: true
+  end
+end

--- a/db/migrate/20200320054512_add_shop_url_column_to_order.rb
+++ b/db/migrate/20200320054512_add_shop_url_column_to_order.rb
@@ -1,0 +1,9 @@
+class AddShopUrlColumnToOrder < ActiveRecord::Migration[5.2]
+  def up
+    add_column :orders, :shop_url, :string
+  end
+
+  def down
+    add_column :orders, :shop_url, :string
+  end
+end

--- a/db/migrate/20200320105731_remove_some_columns_from_order.rb
+++ b/db/migrate/20200320105731_remove_some_columns_from_order.rb
@@ -1,0 +1,13 @@
+class RemoveSomeColumnsFromOrder < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :orders, :item_no
+    remove_column :orders, :item_no_category
+    remove_column :orders, :shop_url
+  end
+
+  def down
+    add_column :orders, :item_no, :integer
+    add_column :orders, :item_no_category, :integer
+    add_column :orders, :shop_url, :string
+  end
+end

--- a/db/migrate/20200320110232_add_shop_url_column_to_item_set.rb
+++ b/db/migrate/20200320110232_add_shop_url_column_to_item_set.rb
@@ -1,0 +1,5 @@
+class AddShopUrlColumnToItemSet < ActiveRecord::Migration[5.2]
+  def change
+    add_column :item_sets, :shop_url, :string
+  end
+end

--- a/db/migrate/20200320123531_remove_item_name_column_from_order.rb
+++ b/db/migrate/20200320123531_remove_item_name_column_from_order.rb
@@ -1,0 +1,9 @@
+class RemoveItemNameColumnFromOrder < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :orders, :item_name
+  end
+
+  def down
+    add_column :orders, :item_name, :string
+  end
+end

--- a/db/migrate/20200321032506_remove_foreign_key_item_unit_from_taobao_url.rb
+++ b/db/migrate/20200321032506_remove_foreign_key_item_unit_from_taobao_url.rb
@@ -1,0 +1,13 @@
+class RemoveForeignKeyItemUnitFromTaobaoUrl < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :taobao_urls, :user, foreign_key: true
+    remove_foreign_key :taobao_urls, :item_units
+    remove_index :taobao_urls, :item_variety_id
+    remove_column :taobao_urls, :item_variety_id
+  end
+
+  def down
+    remove_reference :taobao_urls, :user
+    add_reference :taobao_urls, :item_variety, foreign_key: { to_table: :item_units }
+  end
+end

--- a/db/migrate/20200321071847_create_item_unit_taobao_urls.rb
+++ b/db/migrate/20200321071847_create_item_unit_taobao_urls.rb
@@ -1,0 +1,10 @@
+class CreateItemUnitTaobaoUrls < ActiveRecord::Migration[5.2]
+  def change
+    create_table :item_unit_taobao_urls do |t|
+      t.references :item_unit, foreign_key: true
+      t.references :taobao_url, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200322143314_add_first_candidate_column_to_item_unit.rb
+++ b/db/migrate/20200322143314_add_first_candidate_column_to_item_unit.rb
@@ -1,0 +1,5 @@
+class AddFirstCandidateColumnToItemUnit < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :item_units, :first_candidate, foreign_key: { to_table: :taobao_urls }
+  end
+end

--- a/db/migrate/20200323021556_add_ishave_stock_column_to_taobao_url.rb
+++ b/db/migrate/20200323021556_add_ishave_stock_column_to_taobao_url.rb
@@ -1,0 +1,5 @@
+class AddIshaveStockColumnToTaobaoUrl < ActiveRecord::Migration[5.2]
+  def change
+    add_column :taobao_urls, :is_have_stock, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_02_081413) do
+ActiveRecord::Schema.define(version: 2020_03_21_071847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,21 +31,32 @@ ActiveRecord::Schema.define(version: 2020_02_02_081413) do
     t.index ["actual_item_variety_id"], name: "index_actual_taobao_urls_on_actual_item_variety_id"
   end
 
-  create_table "item_nos", force: :cascade do |t|
+  create_table "item_sets", force: :cascade do |t|
     t.bigint "user_id"
-    t.integer "item_no"
-    t.string "item_name"
+    t.string "item_set_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_item_nos_on_user_id"
+    t.integer "item_no"
+    t.integer "item_no_category", comment: "指定なし,Buyma,Amazon.."
+    t.string "shop_url"
+    t.index ["user_id"], name: "index_item_sets_on_user_id"
   end
 
-  create_table "item_varieties", force: :cascade do |t|
-    t.bigint "item_no_id"
-    t.string "item_taobao_name"
+  create_table "item_unit_taobao_urls", force: :cascade do |t|
+    t.bigint "item_unit_id"
+    t.bigint "taobao_url_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["item_no_id"], name: "index_item_varieties_on_item_no_id"
+    t.index ["item_unit_id"], name: "index_item_unit_taobao_urls_on_item_unit_id"
+    t.index ["taobao_url_id"], name: "index_item_unit_taobao_urls_on_taobao_url_id"
+  end
+
+  create_table "item_units", force: :cascade do |t|
+    t.string "item_unit_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "item_set_id"
+    t.index ["item_set_id"], name: "index_item_units_on_item_set_id"
   end
 
   create_table "orders", force: :cascade do |t|
@@ -60,12 +71,10 @@ ActiveRecord::Schema.define(version: 2020_02_02_081413) do
     t.string "phone"
     t.string "color_size"
     t.string "customer_remark"
-    t.string "item_name"
     t.string "japanese_retailer_remark"
     t.integer "japanese_retailer_status"
     t.bigint "japanese_retailer_id"
     t.bigint "chinese_buyer_id"
-    t.integer "item_no"
     t.integer "estimate_charge"
     t.integer "chinese_buyer_status"
     t.string "chinese_buyer_remark"
@@ -75,7 +84,9 @@ ActiveRecord::Schema.define(version: 2020_02_02_081413) do
     t.integer "international_shipping_fee"
     t.integer "other_fee"
     t.integer "tracking_number"
+    t.bigint "item_set_id"
     t.index ["chinese_buyer_id"], name: "index_orders_on_chinese_buyer_id"
+    t.index ["item_set_id"], name: "index_orders_on_item_set_id"
     t.index ["japanese_retailer_id"], name: "index_orders_on_japanese_retailer_id"
   end
 
@@ -96,11 +107,11 @@ ActiveRecord::Schema.define(version: 2020_02_02_081413) do
   end
 
   create_table "taobao_urls", force: :cascade do |t|
-    t.bigint "item_variety_id"
     t.string "url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["item_variety_id"], name: "index_taobao_urls_on_item_variety_id"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_taobao_urls_on_user_id"
   end
 
   create_table "user_orders", force: :cascade do |t|
@@ -128,13 +139,16 @@ ActiveRecord::Schema.define(version: 2020_02_02_081413) do
 
   add_foreign_key "actual_item_varieties", "orders"
   add_foreign_key "actual_taobao_urls", "actual_item_varieties"
-  add_foreign_key "item_nos", "users"
-  add_foreign_key "item_varieties", "item_nos"
+  add_foreign_key "item_sets", "users"
+  add_foreign_key "item_unit_taobao_urls", "item_units"
+  add_foreign_key "item_unit_taobao_urls", "taobao_urls"
+  add_foreign_key "item_units", "item_sets"
+  add_foreign_key "orders", "item_sets"
   add_foreign_key "orders", "users", column: "chinese_buyer_id"
   add_foreign_key "orders", "users", column: "japanese_retailer_id"
   add_foreign_key "pictures", "orders"
   add_foreign_key "taobao_color_sizes", "orders"
-  add_foreign_key "taobao_urls", "item_varieties"
+  add_foreign_key "taobao_urls", "users"
   add_foreign_key "user_orders", "orders"
   add_foreign_key "user_orders", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_21_071847) do
+ActiveRecord::Schema.define(version: 2020_03_23_021556) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,8 @@ ActiveRecord::Schema.define(version: 2020_03_21_071847) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "item_set_id"
+    t.bigint "first_candidate_id"
+    t.index ["first_candidate_id"], name: "index_item_units_on_first_candidate_id"
     t.index ["item_set_id"], name: "index_item_units_on_item_set_id"
   end
 
@@ -111,6 +113,7 @@ ActiveRecord::Schema.define(version: 2020_03_21_071847) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.integer "is_have_stock", default: 0, null: false
     t.index ["user_id"], name: "index_taobao_urls_on_user_id"
   end
 
@@ -143,6 +146,7 @@ ActiveRecord::Schema.define(version: 2020_03_21_071847) do
   add_foreign_key "item_unit_taobao_urls", "item_units"
   add_foreign_key "item_unit_taobao_urls", "taobao_urls"
   add_foreign_key "item_units", "item_sets"
+  add_foreign_key "item_units", "taobao_urls", column: "first_candidate_id"
   add_foreign_key "orders", "item_sets"
   add_foreign_key "orders", "users", column: "chinese_buyer_id"
   add_foreign_key "orders", "users", column: "japanese_retailer_id"

--- a/test/controllers/item_sets_controller_test.rb
+++ b/test/controllers/item_sets_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemSetsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/item_unit_taobao_urls.yml
+++ b/test/fixtures/item_unit_taobao_urls.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  item_unit: one
+  taobao_url: one
+
+two:
+  item_unit: two
+  taobao_url: two

--- a/test/models/item_unit_taobao_url_test.rb
+++ b/test/models/item_unit_taobao_url_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemUnitTaobaoUrlTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 資料
[仕様書](https://docs.google.com/spreadsheets/d/1Zxj2f7bwlyQNA2s2AJ-m5xN12SFLCvBMYS7MsjJrsCQ/edit#gid=1735276123)
[ER図](https://www.draw.io/?state=%7B%22ids%22:%5B%221Wv2S_TlPrzgQCZYbSRZk9wilaPT4LMBd%22%5D,%22action%22:%22open%22,%22userId%22:%22105826817291988253457%22%7D#G1Wv2S_TlPrzgQCZYbSRZk9wilaPT4LMBd)
[sample_20191126.csv.zip](https://github.com/fukadashigeru/china_trade_system/files/3892239/sample_20191126.csv.zip)

## タスク
- [x] `item_no_category`にコメントを追加する
- [x] `ItemSet`の`item_no`と`item_no_category`をユニークにする
- [x] `shop_url`カラムを`order`テーブルに追加
- [x] 買付先登録をする、buymaの商品idからurlを生成するjs
- [x] tableの横幅をいい感じにする
- [x] belongs_to :item_set, optional: true の optional: true をなくす。 
  - modelだけでなくて、tableのほうに制約かける。
- [x] チェックボックス
- [x] 在庫切れ
- [x] 在庫切れのデータを更新
- [x] フォーム追加非同期処理
- [ ] ~inverse_ofつかえるところあると思うから、修正する~
- [x] DBとかmodelにnull:falseとかつける
![image](https://user-images.githubusercontent.com/45095615/77250100-e580d880-6c88-11ea-8c07-693c262161f1.png)
- [x] taobao_urlの順番をいい感じにする
- [x] controllerの処理をmodelに委譲
- [x] formがからの場合、taobao_urlを削除したりする。
- [x] TaobaoUrlの削除ボタン追加
- [x] 常に3つのtrになるようにする
- [x] jsのhtml修正
- [ ] ~更新がなければ、flashださない。~
- [x] チェックボックスの更新
- [x] item_unitsない場合に削除
- [x] フラッシュメッセージゆっくり消える。
- [x] 在庫切れの切り替えでも処理入れる
- [x] チェックボックスはどれかに入れないといけないという処理
- [ ] ~チェックを消せるようにする。~
- [x] urlがない場合は、チェックが入れれないようにする。
![image](https://user-images.githubusercontent.com/45095615/77253733-867a8e00-6c9f-11ea-9c89-a90779e43120.png)
- [x] first_candidateのモデルのカラムを用意。
- [x] 新規item_setページを開くとチェックボックスが全部入ってる問題。
![image](https://user-images.githubusercontent.com/45095615/77254630-972e0280-6ca5-11ea-9862-55e062ad486e.png)
- [x] next unlessのところいい感じにする
- [ ] enum 勉強する。今はいい感じじゃない。
- [x] 番号にshop_urlを貼るようにする。
![image](https://user-images.githubusercontent.com/45095615/77407568-afaf3180-6df9-11ea-8686-b9d02158863c.png)
- [x] チェックがふたつはいってしまう？飛ばし飛ばしで登録するとなる？
![image](https://user-images.githubusercontent.com/45095615/77431311-dda76c80-6e1f-11ea-875e-962e856274ae.png)
- [x] 在庫切れにすると、優先のチャックマークが入らないようにする。
- [x] 優先のものにチェックを入れるってtooltipを挿入
- [ ] ~優先チェックマークを入れないとpostできない仕様にする。~ → jsでいくらか担保してるので、いいかな。
- [x] 注文の編集ボタンがきかない。カラム変えたからと思われ。
- [x] フロント色々修正したから、jsのhtmlもそれに合わせて修正
- [x] 第一候補のチェックがうまく働いてない
![image](https://user-images.githubusercontent.com/45095615/77659341-4c6cfd00-6fbb-11ea-94e2-427950877265.png)
- [x] チェックボタンとurlのリンク飛ばすやつのjs追加。
![image](https://user-images.githubusercontent.com/45095615/77661499-0feed080-6fbe-11ea-816c-cc1d77a899bd.png)
- [x] 追加ボタンが効かない
![image](https://user-images.githubusercontent.com/45095615/77672205-f2c0fe80-6fcb-11ea-8740-88f830918722.png)
- [x] チェックボックスの登録がitem_unitごとに適応されてない
- [x] item_unitがなかったら削除する処理
- [ ] 入力がないときにsubmitできないようにするとか？
- [x] 在庫無しにしてチェックがはずれたら、次のやつにチェックいれるよなjs処理入れる
- [x] item_unitが逆になることがある。
![image](https://user-images.githubusercontent.com/45095615/77823440-96322080-713e-11ea-8e17-c2d672eecc4e.png)
- [ ] 同じの登録できないようにする。modelとjsで処理しよう。
![image](https://user-images.githubusercontent.com/45095615/77823832-77815900-7141-11ea-8d08-08de9f9cda56.png)
